### PR TITLE
ALM-004 changes to reading report definitions

### DIFF
--- a/api/src/main/java/com/lantanagroup/link/api/ApiInit.java
+++ b/api/src/main/java/com/lantanagroup/link/api/ApiInit.java
@@ -4,13 +4,9 @@ import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.parser.IParser;
 import ca.uhn.fhir.rest.client.api.ServerValidationModeEnum;
 import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException;
-import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
-import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.lantanagroup.link.*;
-import com.lantanagroup.link.auth.OAuth2Helper;
 import com.lantanagroup.link.config.api.ApiConfig;
-import com.lantanagroup.link.config.api.ApiReportDefsUrlConfig;
-import com.lantanagroup.link.config.auth.LinkOAuthConfig;
+import com.lantanagroup.link.config.api.ApiReportDefsBundleConfig;
 import com.lantanagroup.link.config.query.QueryConfig;
 import com.lantanagroup.link.config.query.USCoreConfig;
 import lombok.Setter;
@@ -18,8 +14,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.CapabilityStatement;
-import org.hl7.fhir.r4.model.Measure;
-import org.hl7.fhir.r4.model.Meta;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,16 +21,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.Resource;
 
 import java.io.BufferedReader;
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -65,7 +51,6 @@ public class ApiInit {
 
     boolean allServicesAvailable = false;
     boolean dataStoreAvailable = false;
-    boolean terminologyServiceAvailable = false;
     boolean evaluationServiceAvailable = false;
 
     for (int retry = 0; config.getMaxRetry() == null || retry <= config.getMaxRetry(); retry++) {
@@ -73,28 +58,33 @@ public class ApiInit {
       // Check data store availability
       if (!dataStoreAvailable) {
         try {
-          CapabilityStatement cs = new FhirDataProvider(config.getDataStore()).getClient().capabilities().ofType(CapabilityStatement.class).execute();
-          logger.info(String.format("CapabilityStatement: %s -- %d", cs.getUrl(), cs.getRest().size()));
+          CapabilityStatement cs = new FhirDataProvider(config.getDataStore())
+                  .getClient()
+                  .capabilities()
+                  .ofType(CapabilityStatement.class)
+                  .execute();
+          logger.info(String.format("Data Store at %s, FHIR Version: %s, Implementation: %s, Software: %s %s",
+                  config.getDataStore().getBaseUrl(),
+                  cs.getFhirVersion().toString(),
+                  cs.getImplementation().getDescription(),
+                  cs.getSoftware().getName(),
+                  cs.getSoftware().getVersion()));
           dataStoreAvailable = true;
         } catch (BaseServerResponseException e) {
           logger.error(String.format("Could not connect to data store %s (%s)", config.getDataStore().getBaseUrl(), e));
         }
       }
 
-      // Check terminology service availability
-      if (!terminologyServiceAvailable) {
-        try {
-          new FhirDataProvider(config.getTerminologyService()).getClient().capabilities().ofType(CapabilityStatement.class).execute();
-          terminologyServiceAvailable = true;
-        } catch (BaseServerResponseException e) {
-          logger.error(String.format("Could not connect to terminology service %s (%s)", config.getTerminologyService(), e));
-        }
-      }
-
       // Check evaluation service availability
       if (!evaluationServiceAvailable) {
         try {
-          new FhirDataProvider(config.getEvaluationService()).getClient().capabilities().ofType(CapabilityStatement.class).execute();
+          CapabilityStatement cs = new FhirDataProvider(config.getEvaluationService()).getClient().capabilities().ofType(CapabilityStatement.class).execute();
+          logger.info(String.format("Evaluation Service at %s, FHIR Version: %s, Implementation: %s, Software: %s %s",
+                  config.getEvaluationService(),
+                  cs.getFhirVersion().toString(),
+                  cs.getImplementation().getDescription(),
+                  cs.getSoftware().getName(),
+                  cs.getSoftware().getVersion()));
           evaluationServiceAvailable = true;
         } catch (BaseServerResponseException e) {
           logger.error(String.format("Could not connect to evaluation service %s (%s)", config.getEvaluationService(), e));
@@ -103,7 +93,7 @@ public class ApiInit {
 
 
       // Check if all services are now available
-      allServicesAvailable = dataStoreAvailable && terminologyServiceAvailable && evaluationServiceAvailable;
+      allServicesAvailable = dataStoreAvailable && evaluationServiceAvailable;
       if (allServicesAvailable) {
         logger.info("All prerequisite services in API init are available.");
         break;
@@ -117,144 +107,56 @@ public class ApiInit {
 
     // Not all prerequisite services are available... cannot continue
     if (!allServicesAvailable) {
-      logger.error(String.format("API prerequisite services are not available.  Availability: data-store: %s, terminology-service: %s, evaluation-service: %s",
-              dataStoreAvailable, terminologyServiceAvailable, evaluationServiceAvailable));
+      logger.error(String.format("API prerequisite services are not available.  Availability: data-store: %s, evaluation-service: %s",
+              dataStoreAvailable, evaluationServiceAvailable));
       return false;
     }
 
     return true;
   }
 
-  private void loadMeasureDefinitions() {
-    HttpClient client = HttpClient.newHttpClient();
-    config.getReportDefs().getUrls().parallelStream().forEach(urlConfig -> {
-      String bundleId = urlConfig.getBundleId();
-      logger.info(String.format("Loading report def for %s", bundleId));
-      Bundle localBundle = null;
-      try {
-        localBundle = provider.getBundleById(bundleId);
-      } catch (ResourceNotFoundException ignored) {
-      }
-      try {
-        loadMeasureDefinition(client, urlConfig, localBundle);
-      } catch (Exception e) {
-        logger.error(String.format("Error loading report def for %s", bundleId), e);
-      }
-    });
-  }
+  /**
+   * Tags each Report Definition configured to be used by the API.
+   * These are configured in api.report-defs, typically loaded
+   * on the Evaluation/CQF Service.  Here we tag them so that they
+   * can be found in ReportDefinitionController.getMeasures and yes
+   * I know there is surely a better way.
+   */
+  private void tagReportDefinitions() {
+    FhirDataProvider evaluationService = new FhirDataProvider(config.getEvaluationService());
+    logger.info("Tagging Report Definitions with System '{}' and Code '{}'",
+            Constants.MainSystem,
+            Constants.ReportDefinitionTag);
 
-  public Bundle loadMeasureDefinition(
-          HttpClient client,
-          ApiReportDefsUrlConfig urlConfig,
-          Bundle localBundle)
-          throws Exception {
+    config.getReportDefs().getBundles().parallelStream().forEach(
+            bundleConfig -> {
 
-    // Check that URL is HTTPS if required
-    URI uri = new URI(urlConfig.getUrl());
-    if (config.isRequireHttps() && !"https".equalsIgnoreCase(uri.getScheme())) {
-      throw new IllegalStateException("URL is not HTTPS");
-    }
-    HttpRequest.Builder requestBuilder = HttpRequest.newBuilder(uri);
+              logger.info("Pulling Report Definition - {}",
+                      bundleConfig.getBundleId());
 
-    // Add If-Modified-Since header based on local bundle
-    if (localBundle != null && localBundle.getMeta().hasLastUpdated()) {
-      SimpleDateFormat format = new SimpleDateFormat(Helper.RFC_1123_DATE_TIME_FORMAT);
-      Date lastUpdated = localBundle.getMeta().getLastUpdated();
-      requestBuilder.setHeader("If-Modified-Since", format.format(lastUpdated));
-    }
+              Bundle measureBundle = evaluationService.getBundleById(bundleConfig.getBundleId());
 
-    // Add Authorization header if configured
-    LinkOAuthConfig authConfig = config.getReportDefs().getAuth();
-    if (authConfig != null) {
-      String token = OAuth2Helper.getToken(authConfig);
-      if (OAuth2Helper.validateHeaderJwtToken(token)) {
-        requestBuilder.setHeader("Authorization", "Bearer " + token);
-      } else {
-        throw new JWTVerificationException("Invalid token format");
-      }
-    }
-
-    // Retrieve remote bundle, retrying if necessary
-    HttpRequest request = requestBuilder.build();
-    HttpResponse<String> response = null;
-    for (int retry = 1; retry <= config.getReportDefs().getMaxRetry(); retry++) {
-      logger.debug("Retrieving report def");
-      try {
-        response = client.send(request, HttpResponse.BodyHandlers.ofString());
-        break;
-      } catch (IOException e) {
-        logger.warn(String.format("Error retrieving report def: %s", e.getMessage()));
-      }
-      int retryWait = config.getReportDefs().getRetryWait();
-      logger.debug(String.format("Retrying in %d milliseconds", retryWait));
-      try {
-        Thread.sleep(retryWait);
-      } catch (InterruptedException ignored) {
-      }
-    }
-    if (response == null || (response.statusCode() != 200 && response.statusCode() != 304)) {
-      throw new Exception("Failed to retrieve report def");
-    }
-
-    // Return local bundle if up to date
-    if (response.statusCode() == 304) {
-      logger.debug("Report def is up to date; not storing");
-      return localBundle;
-    }
-
-    // Parse and validate remote bundle
-    Bundle remoteBundle = FhirHelper.parseResource(Bundle.class, response.body());
-    if (!FhirHelper.validLibraries(remoteBundle)) {
-      throw new Exception("Report def contains libraries without data requirements");
-    }
-
-    List<String> otherResourceTypes = this.usCoreConfig.getOtherResourceTypes().stream()
-            .map(ort -> ort.getResourceType())
-            .collect(Collectors.toList());
-    List<String> allResourceTypes = Helper.concatenate(this.usCoreConfig.getPatientResourceTypes(), otherResourceTypes);
-    List<String> missingResourceTypes = FhirHelper.getQueryConfigurationDataReqMissingResourceTypes(
-            allResourceTypes,
-            remoteBundle);
-
-    if (!missingResourceTypes.isEmpty()) {
-      logger.warn(String.format(
-              "Report def contains data requirements that are not configured for querying: %s",
-              String.join(", ", missingResourceTypes)));
-    }
-
-    // Store to terminology service
-    logger.debug("Storing to terminology service");
-    Bundle evaluationBundle = FhirHelper.storeTerminologyAndReturnOther(remoteBundle, config);
-
-    // Set ID, meta
-    String bundleId = urlConfig.getBundleId();
-    evaluationBundle.setId(bundleId);
-    evaluationBundle.setMeta(localBundle != null
-            ? localBundle.getMeta()
-            : new Meta().addTag(Constants.MainSystem, Constants.ReportDefinitionTag, null));
-
-    Measure measure = FhirHelper.getMeasure(remoteBundle);
-    if (!measure.hasIdentifier()) {
-      logger.error(String.format("Measure : %s does not have an identifier.", measure.getId()));
-      measure.addIdentifier().setSystem(Constants.MainSystem).setValue(bundleId);
-    }
-
-    // Store to evaluation service and internal data store
-    logger.debug("Storing to evaluation service");
-    FhirDataProvider evaluationProvider = new FhirDataProvider(config.getEvaluationService());
-    evaluationProvider.transaction(evaluationBundle);
-    logger.debug("Storing to internal data store");
-    provider.updateResource(evaluationBundle);
-    return evaluationBundle;
+              if (measureBundle.getMeta().getTag(Constants.MainSystem, Constants.ReportDefinitionTag) == null) {
+                logger.info("Tagging and Saving Report Definition - {}",
+                        bundleConfig.getBundleId());
+                measureBundle.getMeta().addTag(Constants.MainSystem, Constants.ReportDefinitionTag, null);
+                evaluationService.updateResource(measureBundle);
+              } else {
+                logger.info("Report Definition - {} - already tagged",
+                        bundleConfig.getBundleId());
+              }
+            }
+    );
   }
 
   private void loadSearchParameters() {
+    // TODO - update these search params in repo (if necessary)
     try {
       FhirContext ctx = FhirContextProvider.getFhirContext();
       IParser xmlParser = ctx.newXmlParser();
       logger.info(String.format("Resources count: %d", resources.length));
       for (final Resource res : resources) {
-        try (InputStream inputStream = res.getInputStream();) {
+        try (InputStream inputStream = res.getInputStream()) {
           IBaseResource resource = readFileAsFhirResource(xmlParser, inputStream);
           provider.updateResource(resource);
         }
@@ -275,7 +177,7 @@ public class ApiInit {
       try {
         socketTimeout = Integer.parseInt(config.getSocketTimeout());
       } catch (Exception ex) {
-        logger.error(String.format("Error % in socket-timeout %s ", ex.getMessage(), config.getSocketTimeout()));
+        logger.error(String.format("Error %s in socket-timeout %s ", ex.getMessage(), config.getSocketTimeout()));
       }
     }
     return socketTimeout;
@@ -284,12 +186,21 @@ public class ApiInit {
   public void init() {
     this.ctx.getRestfulClientFactory().setSocketTimeout(getSocketTimout());
 
+    Optional<ApiReportDefsBundleConfig> measureReportAggregator = config.getReportDefs().getBundles().stream().filter(bundleConfig -> StringUtils.isEmpty(bundleConfig.getReportAggregator())).findFirst();
+    if (StringUtils.isEmpty(config.getReportAggregator()) && measureReportAggregator.isPresent()) {
+      String msg = "Not all measures have aggregators configured and there is no default aggregator in the configuration file.";
+      logger.error(msg);
+      throw new IllegalStateException(msg);
+    }
+    /*
     Optional<ApiReportDefsUrlConfig> measureReportAggregator = config.getReportDefs().getUrls().stream().filter(urlConfig -> StringUtils.isEmpty(urlConfig.getReportAggregator())).findFirst();
     if (StringUtils.isEmpty(config.getReportAggregator()) && !measureReportAggregator.isEmpty()) {
       String msg = "Not all measures have aggregators configured and there is no default aggregator in the configuration file.";
       logger.error(msg);
       throw new IllegalStateException(msg);
     }
+
+     */
 
     if (this.queryConfig.isRequireHttps() && !this.usCoreConfig.getFhirServerBase().toLowerCase().startsWith("https://")) {
       throw new IllegalStateException("Error, Query URL requires https");
@@ -311,9 +222,13 @@ public class ApiInit {
       throw new IllegalStateException("Prerequisite services check failed. Cannot continue API initialization.");
     }
 
-    this.loadMeasureDefinitions();
-    this.loadSearchParameters();
-
+    // ALM 28Jun2023 - for now I have commented this out because it
+    // pulls an OLD measure from nshslink.org and loads that onto the CQF and DataStore servers
+    // So even though when spinning up a new CQF I was loading the correct Measure, this was
+    // overwriting it.
+    //this.loadMeasureDefinitions();
+    //this.loadSearchParameters();
+    this.tagReportDefinitions();
   }
 
 }

--- a/api/src/main/java/com/lantanagroup/link/api/MeasureEvaluator.java
+++ b/api/src/main/java/com/lantanagroup/link/api/MeasureEvaluator.java
@@ -38,17 +38,6 @@ public class MeasureEvaluator {
     return evaluator.generateMeasureReport();
   }
 
-  private static Endpoint getTerminologyEndpoint(ApiConfig config) {
-    Endpoint terminologyEndpoint = new Endpoint();
-    terminologyEndpoint.setStatus(Endpoint.EndpointStatus.ACTIVE);
-    terminologyEndpoint.setConnectionType(new Coding());
-    terminologyEndpoint.getConnectionType().setSystem(Constants.TerminologyEndpointSystem);
-    terminologyEndpoint.getConnectionType().setCode(Constants.TerminologyEndpointCode);
-    terminologyEndpoint.setAddress(config.getTerminologyService());
-    return terminologyEndpoint;
-  }
-
-
   private MeasureReport generateMeasureReport() {
     MeasureReport measureReport;
     String patientDataBundleId = ReportIdHelper.getPatientDataBundleId(reportContext.getMasterIdentifierValue(), patientId);
@@ -79,11 +68,6 @@ public class MeasureEvaluator {
       parameters.addParameter().setName("periodEnd").setValue(new StringType(this.criteria.getPeriodEnd().substring(0, this.criteria.getPeriodEnd().indexOf("."))));
       parameters.addParameter().setName("subject").setValue(new StringType(patientId));
       parameters.addParameter().setName("additionalData").setResource((Bundle) patientBundle);
-      if (!this.config.getEvaluationService().equals(this.config.getTerminologyService())) {
-        Endpoint terminologyEndpoint = getTerminologyEndpoint(this.config);
-        parameters.addParameter().setName("terminologyEndpoint").setResource(terminologyEndpoint);
-        logger.info("evaluate-measure is being executed with the terminologyEndpoint parameter.");
-      }
 
       logger.info(String.format("Evaluating measure for patient %s and measure %s", patientId, measureId));
       Date measureEvalStartTime = new Date();

--- a/api/src/main/java/com/lantanagroup/link/api/controller/ReportDefinitionController.java
+++ b/api/src/main/java/com/lantanagroup/link/api/controller/ReportDefinitionController.java
@@ -1,10 +1,15 @@
 package com.lantanagroup.link.api.controller;
 
+import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.lantanagroup.link.Constants;
 import com.lantanagroup.link.FhirDataProvider;
+import com.lantanagroup.link.FhirHelper;
+import com.lantanagroup.link.auth.OAuth2Helper;
 import com.lantanagroup.link.config.api.ApiConfig;
+import com.lantanagroup.link.config.auth.LinkOAuthConfig;
 import com.lantanagroup.link.model.StoredMeasure;
 import lombok.Setter;
+import org.apache.catalina.Store;
 import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Measure;
@@ -15,6 +20,12 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -28,7 +39,8 @@ public class ReportDefinitionController extends BaseController {
   ApiConfig config;
 
   /**
-   * Responds with a list of the measures stored in the system
+   * Responds with a list of the measures configured for use by API
+   * and stored on the Evaluation/CQF Service
    *
    * @param authentication Who the user is authenticated as
    * @param request        The REST request
@@ -37,10 +49,13 @@ public class ReportDefinitionController extends BaseController {
    */
   @GetMapping
   public List<StoredMeasure> getMeasures(Authentication authentication, HttpServletRequest request) throws Exception {
-    FhirDataProvider fhirClient = this.getFhirDataProvider();
+    FhirDataProvider evaluationProvider = new FhirDataProvider(config.getEvaluationService());
 
-    // Find all Bundles with the measure tag
-    Bundle searchResults = fhirClient.searchBundleByTag(Constants.MainSystem, Constants.ReportDefinitionTag);
+    //FhirDataProvider fhirClient = this.getFhirDataProvider();
+    //Bundle searchResults = fhirClient.searchBundleByTag(Constants.MainSystem, Constants.ReportDefinitionTag);
+
+    // Find all Bundles with the measure tag on CQF/Evaluation
+    Bundle searchResults = evaluationProvider.searchBundleByTag(Constants.MainSystem, Constants.ReportDefinitionTag);
 
     List<StoredMeasure> storedMeasures = searchResults.getEntry().stream().map(e -> {
       Bundle reportDefinitionBundle = (Bundle) e.getResource();

--- a/core/src/main/java/com/lantanagroup/link/config/api/ApiConfig.java
+++ b/core/src/main/java/com/lantanagroup/link/config/api/ApiConfig.java
@@ -83,14 +83,6 @@ public class ApiConfig {
   private String evaluationService;
 
   /**
-   * <strong>api.terminology-service</strong><br>The FHIR terminology service to use for storing ValueSet and CodeSystem resources, passed to the evaluation-service for use during measure evaluation.
-   */
-  @Getter
-  @Setter
-  @NotNull
-  private String terminologyService;
-
-  /**
    * <strong>api.auth-jwks-url</strong><br>The url endpoint for certs from the identity provider, which is used to verify any JSON Web Token (JWT)
    */
   @Getter

--- a/core/src/main/java/com/lantanagroup/link/config/api/ApiReportDefsBundleConfig.java
+++ b/core/src/main/java/com/lantanagroup/link/config/api/ApiReportDefsBundleConfig.java
@@ -1,0 +1,24 @@
+package com.lantanagroup.link.config.api;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.validation.annotation.Validated;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@Setter
+@Validated
+public class ApiReportDefsBundleConfig {
+    /**
+     * <strong>api.report-defs.bundles.bundle-id</strong><br>ID of stored Bundle.
+     */
+    @NotBlank
+    private String bundleId;
+
+    /**
+     * <strong>api.report-defs.bundles.report-aggregator</strong><br>Aggregator used to aggregate for that measure.
+     */
+    private String reportAggregator;
+
+}

--- a/core/src/main/java/com/lantanagroup/link/config/api/ApiReportDefsConfig.java
+++ b/core/src/main/java/com/lantanagroup/link/config/api/ApiReportDefsConfig.java
@@ -23,21 +23,13 @@ public class ApiReportDefsConfig {
   public int retryWait = 5000;
 
   /**
-   * <strong>api.report-defs.urls</strong><br>A list of report definitions for each measure that should be supported by the system.
+   * <strong>api.report-defs.bundles</strong><br>A list of report definition bundles identifiers and report aggregators which can be used and shoudl be loaded on Evaluation/CQF service.
    */
-  public List<ApiReportDefsUrlConfig> urls;
+  public List<ApiReportDefsBundleConfig> bundles;
 
   /**
    * <strong>api.report-defs.auth</strong><br>A list of authentication properties.
    */
   public LinkOAuthConfig auth;
 
-  public ApiReportDefsUrlConfig getUrlByBundleId(String bundleId) {
-    for (ApiReportDefsUrlConfig url : urls) {
-      if (url.getBundleId().equals(bundleId)) {
-        return url;
-      }
-    }
-    return null;
-  }
 }

--- a/core/src/test/java/com/lantanagroup/link/FhirHelperTests.java
+++ b/core/src/test/java/com/lantanagroup/link/FhirHelperTests.java
@@ -4,6 +4,7 @@ import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.rest.api.MethodOutcome;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.lantanagroup.link.config.api.ApiConfig;
+import com.lantanagroup.link.config.api.ApiReportDefsBundleConfig;
 import com.lantanagroup.link.config.api.ApiReportDefsConfig;
 import com.lantanagroup.link.config.api.ApiReportDefsUrlConfig;
 import org.hl7.fhir.instance.model.api.IBaseResource;
@@ -99,14 +100,15 @@ public class FhirHelperTests {
     ApiConfig apiConfig = new ApiConfig();
     apiConfig.setReportAggregator("");
     ApiReportDefsConfig apiReportDefsConfig = new ApiReportDefsConfig();
-    List<ApiReportDefsUrlConfig> apiReportDefsConfigList = new ArrayList<>();
-    apiReportDefsConfig.setUrls(apiReportDefsConfigList);
-    ApiReportDefsUrlConfig apiReportDefsUrlConfig = new ApiReportDefsUrlConfig();
-    apiReportDefsUrlConfig.setUrl("https://ehr-test.nhsnlink.org/fhir/Bundle/NHSNGlycemicControlHypoglycemicInitialPopulation");
-    apiReportDefsUrlConfig.setBundleId("NHSNGlycemicControlHypoglycemicInitialPopulation");
-    apiReportDefsUrlConfig.setReportAggregator("com.lantanagroup.link.nhsn.ReportAggregator");
+
+    ApiReportDefsBundleConfig apiReportDefsBundleConfig = new ApiReportDefsBundleConfig();
+    apiReportDefsBundleConfig.setBundleId("NHSNGlycemicControlHypoglycemicInitialPopulation");
+    apiReportDefsBundleConfig.setReportAggregator("com.lantanagroup.link.nhsn.ReportAggregator");
+    List<ApiReportDefsBundleConfig> apiReportDefsBundleConfigList = new ArrayList<>();
+    apiReportDefsBundleConfigList.add(apiReportDefsBundleConfig);
+    apiReportDefsConfig.setBundles(apiReportDefsBundleConfigList);
     apiConfig.setReportDefs(apiReportDefsConfig);
-    apiReportDefsConfigList.add(apiReportDefsUrlConfig);
+
     Bundle bundle = new Bundle();
     bundle.setId("NHSNGlycemicControlHypoglycemicInitialPopulation");
     String reportAggregatorClassName = FhirHelper.getReportAggregatorClassName(apiConfig, bundle);
@@ -118,14 +120,26 @@ public class FhirHelperTests {
     ApiConfig apiConfig = new ApiConfig();
     apiConfig.setReportAggregator("com.lantanagroup.link.nhsn.ReportAggregator");
     ApiReportDefsConfig apiReportDefsConfig = new ApiReportDefsConfig();
+
+    ApiReportDefsBundleConfig apiReportDefsBundleConfig = new ApiReportDefsBundleConfig();
+    apiReportDefsBundleConfig.setBundleId("NHSNGlycemicControlHypoglycemicInitialPopulation");
+    apiReportDefsBundleConfig.setReportAggregator("");
+    List<ApiReportDefsBundleConfig> apiReportDefsBundleConfigList = new ArrayList<>();
+    apiReportDefsBundleConfigList.add(apiReportDefsBundleConfig);
+    apiReportDefsConfig.setBundles(apiReportDefsBundleConfigList);
+    apiConfig.setReportDefs(apiReportDefsConfig);
+
+    /*
     List<ApiReportDefsUrlConfig> apiReportDefsConfigList = new ArrayList<>();
-    apiReportDefsConfig.setUrls(apiReportDefsConfigList);
+    //apiReportDefsConfig.setUrls(apiReportDefsConfigList);
     ApiReportDefsUrlConfig apiReportDefsUrlConfig = new ApiReportDefsUrlConfig();
     apiReportDefsUrlConfig.setUrl("https://ehr-test.nhsnlink.org/fhir/Bundle/NHSNGlycemicControlHypoglycemicInitialPopulation");
     apiReportDefsUrlConfig.setBundleId("NHSNGlycemicControlHypoglycemicInitialPopulation");
     apiReportDefsUrlConfig.setReportAggregator("");
     apiConfig.setReportDefs(apiReportDefsConfig);
     apiReportDefsConfigList.add(apiReportDefsUrlConfig);
+
+     */
     Bundle bundle = new Bundle();
     bundle.setId("NHSNGlycemicControlHypoglycemicInitialPopulation");
     String reportAggregatorClassName = FhirHelper.getReportAggregatorClassName(apiConfig, bundle);
@@ -137,14 +151,26 @@ public class FhirHelperTests {
     ApiConfig apiConfig = new ApiConfig();
     apiConfig.setReportAggregator("");
     ApiReportDefsConfig apiReportDefsConfig = new ApiReportDefsConfig();
+
+    ApiReportDefsBundleConfig apiReportDefsBundleConfig = new ApiReportDefsBundleConfig();
+    apiReportDefsBundleConfig.setBundleId("THSAMeasure");
+    apiReportDefsBundleConfig.setReportAggregator("com.lantanagroup.link.thsa.THSAAggregator");
+    List<ApiReportDefsBundleConfig> apiReportDefsBundleConfigList = new ArrayList<>();
+    apiReportDefsBundleConfigList.add(apiReportDefsBundleConfig);
+    apiReportDefsConfig.setBundles(apiReportDefsBundleConfigList);
+    apiConfig.setReportDefs(apiReportDefsConfig);
+
+    /*
     List<ApiReportDefsUrlConfig> apiReportDefsConfigList = new ArrayList<>();
-    apiReportDefsConfig.setUrls(apiReportDefsConfigList);
+    //apiReportDefsConfig.setUrls(apiReportDefsConfigList);
     ApiReportDefsUrlConfig apiReportDefsUrlConfig = new ApiReportDefsUrlConfig();
     apiReportDefsUrlConfig.setUrl("https://ehr-test.nhsnlink.org/fhir/Bundle/THSAMeasure");
     apiReportDefsUrlConfig.setBundleId("THSAMeasure");
     apiReportDefsUrlConfig.setReportAggregator("com.lantanagroup.link.thsa.THSAAggregator");
     apiConfig.setReportDefs(apiReportDefsConfig);
     apiReportDefsConfigList.add(apiReportDefsUrlConfig);
+
+     */
     Bundle bundle = new Bundle();
     bundle.setId("THSAMeasure");
     String reportAggregatorClassName = FhirHelper.getReportAggregatorClassName(apiConfig, bundle);


### PR DESCRIPTION
Removed Terminology Service.   api.report-defs now just have a bundles section with an id & aggregator.  These are assumed/must be loaded on the Evaluation Service.

Configured api.report-defs bundles are "tagged" with Constants.MainSystem and Constants.ReportDefinitionTag as API starts.  Useful at this point only when /api/measure is called so it can find the Bundles.