### PR TITLE
Added parameter to deleteReport in ReportController.java that allows …

### DIFF
--- a/api/src/main/java/com/lantanagroup/link/api/controller/ReportController.java
+++ b/api/src/main/java/com/lantanagroup/link/api/controller/ReportController.java
@@ -630,9 +630,12 @@ public class ReportController extends BaseController {
   @DeleteMapping(value = "/{id}")
   public void deleteReport(
           @PathVariable("id") String id,
+          @RequestParam(required = false) Boolean ignoreVersionCheck,
           Authentication authentication,
           HttpServletRequest request) throws Exception {
     Bundle deleteRequest = new Bundle();
+
+    Boolean skipVersionCheck = ignoreVersionCheck != null ? ignoreVersionCheck : false;
 
     // TODO - revisit this.
     // ALM 15May2023
@@ -651,7 +654,9 @@ public class ReportController extends BaseController {
 
     Extension existingVersionExt = documentReference.getExtensionByUrl(Constants.DocumentReferenceVersionUrl);
     Float existingVersion = Float.parseFloat(existingVersionExt.getValue().toString());
-    if (existingVersion >= 1.0f) {
+
+    // only ignore the version check of ignoreVersionCheck is passed via command line
+    if ( (existingVersion >= 1.0f) && (!skipVersionCheck) ) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Report version is greater than or equal to 1.0");
     }
 


### PR DESCRIPTION
…you to ignore the version check.  Needed this in PoC because of issues w/ Measure were information wasn't getting pickedup correctly.  But because of expunge the patient lists were gone... so the regenerate wasn't an option.