### PR TITLE
THSALINK-022

### DIFF
--- a/cli/src/main/java/com/lantanagroup/link/cli/RefreshPatientListCommand.java
+++ b/cli/src/main/java/com/lantanagroup/link/cli/RefreshPatientListCommand.java
@@ -4,7 +4,6 @@ import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 import ca.uhn.fhir.rest.client.api.ServerValidationModeEnum;
 import ca.uhn.fhir.rest.client.impl.BaseClient;
-
 import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.lantanagroup.link.Constants;
 import com.lantanagroup.link.FhirContextProvider;
@@ -14,6 +13,7 @@ import com.lantanagroup.link.config.query.QueryConfig;
 import com.lantanagroup.link.query.auth.EpicAuth;
 import com.lantanagroup.link.query.auth.EpicAuthConfig;
 import com.lantanagroup.link.query.auth.HapiFhirAuthenticationInterceptor;
+import com.lantanagroup.link.tasks.RefreshPatientListTask;
 import com.lantanagroup.link.tasks.config.CensusReportingPeriods;
 import com.lantanagroup.link.tasks.config.RefreshPatientListConfig;
 import org.apache.http.HttpHeaders;
@@ -56,17 +56,20 @@ public class RefreshPatientListCommand extends BaseShellCommand {
     config = applicationContext.getBean(RefreshPatientListConfig.class);
     queryConfig = applicationContext.getBean(QueryConfig.class);
 
-    List<RefreshPatientListConfig.PatientList> filteredList = config.getPatientList();
+    RefreshPatientListTask.RunRefreshPatientList(config, queryConfig, applicationContext);
 
-    for (RefreshPatientListConfig.PatientList listResource : filteredList) {
-      logger.info("Reading List - {}", listResource.getPatientListPath());
-      ListResource source = readList(listResource.getPatientListPath());
-      logger.info("List has {} items", source.getEntry().size());
-      for (int j = 0; j < listResource.getCensusIdentifier().size(); j++) {
-        ListResource target = transformList(source, listResource.getCensusIdentifier().get(j));
-        updateList(target);
-      }
-    }
+
+//    List<RefreshPatientListConfig.PatientList> filteredList = config.getPatientList();
+//
+//    for (RefreshPatientListConfig.PatientList listResource : filteredList) {
+//      logger.info("Reading List - {}", listResource.getPatientListPath());
+//      ListResource source = readList(listResource.getPatientListPath());
+//      logger.info("List has {} items", source.getEntry().size());
+//      for (int j = 0; j < listResource.getCensusIdentifier().size(); j++) {
+//        ListResource target = transformList(source, listResource.getCensusIdentifier().get(j));
+//        updateList(target);
+//      }
+//    }
   }
 
   private ListResource readList(String patientListId) throws ClassNotFoundException {

--- a/link-lambda/src/main/java/ExpungeData.java
+++ b/link-lambda/src/main/java/ExpungeData.java
@@ -16,17 +16,24 @@ public class ExpungeData implements RequestHandler<Void,String> {
         String returnValue = "";
 
         try {
+            logger.info("ExpungeData Lambda - Started");
+
             String secretName = System.getenv("API_AUTH_SECRET");
             Region region = Region.of(System.getenv("AWS_REGION"));
             String expungeApiUrl = System.getenv("API_ENDPOINT");
+            logger.info("Environment Variables Read");
 
             LinkOAuthConfig authConfig = Utility.GetLinkOAuthConfigFromAwsSecrets(region, secretName);
+            logger.info("LinkOAuthConfig Created");
 
             ExpungeDataConfig config = new ExpungeDataConfig();
             config.setApiUrl(expungeApiUrl);
             config.setAuth(authConfig);
+            logger.info("ExpungeDataConfig Created");
 
             ExpungeDataTask.RunExpungeDataTask(config);
+
+            logger.info("ExpungeData Lambda - Completed");
         } catch (Exception ex) {
             throw new RuntimeException(ex);
         }

--- a/link-lambda/src/main/java/ExpungeData.java
+++ b/link-lambda/src/main/java/ExpungeData.java
@@ -7,6 +7,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.regions.Region;
 
+//aws ecr-public get-login-password --region us-east-1 --profile starhie | docker login --username AWS --password-stdin public.ecr.aws/lambda/java
 public class ExpungeData implements RequestHandler<Void,String> {
 
     private static final Logger logger = LoggerFactory.getLogger(ExpungeDataTask.class);

--- a/link-lambda/src/main/java/ExpungeData.java
+++ b/link-lambda/src/main/java/ExpungeData.java
@@ -3,15 +3,9 @@ import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.lantanagroup.link.config.auth.LinkOAuthConfig;
 import com.lantanagroup.link.tasks.ExpungeDataTask;
 import com.lantanagroup.link.tasks.config.ExpungeDataConfig;
-import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
-import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
-import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
-
 
 public class ExpungeData implements RequestHandler<Void,String> {
 
@@ -22,38 +16,11 @@ public class ExpungeData implements RequestHandler<Void,String> {
         String returnValue = "";
 
         try {
-            String secretName = System.getenv("SECRET_NAME"); // "expunge-data-testing";
-            Region region = Region.of(System.getenv("AWS_REGION")); // "us-east-1"
-            String expungeApiUrl = System.getenv("EXPUNGE_API_URL"); // "https://thsa1.sanerproject.org:10440/api/data/expunge";
+            String secretName = System.getenv("API_AUTH_SECRET");
+            Region region = Region.of(System.getenv("AWS_REGION"));
+            String expungeApiUrl = System.getenv("API_ENDPOINT");
 
-            // Create a Secrets Manager client
-            SecretsManagerClient client = SecretsManagerClient.builder()
-                    .region(region)
-                    .httpClient(ApacheHttpClient.create())
-                    .build();
-
-            GetSecretValueRequest getSecretValueRequest = GetSecretValueRequest.builder()
-                    .secretId(secretName)
-                    .build();
-
-            GetSecretValueResponse getSecretValueResponse;
-
-            getSecretValueResponse = client.getSecretValue(getSecretValueRequest);
-
-            String secret = getSecretValueResponse.secretString();
-
-            JSONObject secretObject = new JSONObject(secret);
-
-            // TODO - probably can find some better way to create this obj using the JSON from secrets manager
-            LinkOAuthConfig authConfig = new LinkOAuthConfig();
-            authConfig.setTokenUrl(secretObject.getString("token-url"));
-            authConfig.setClientId(secretObject.getString("client-id"));
-            authConfig.setClientSecret(secretObject.getString("client-secret"));
-            authConfig.setUsername(secretObject.getString("username"));
-            authConfig.setPassword(secretObject.getString("password"));
-            authConfig.setScope(secretObject.getString("scope"));
-            authConfig.setCredentialMode(secretObject.getString("credential-mode"));
-
+            LinkOAuthConfig authConfig = Utility.GetLinkOAuthConfigFromAwsSecrets(region, secretName);
 
             ExpungeDataConfig config = new ExpungeDataConfig();
             config.setApiUrl(expungeApiUrl);

--- a/link-lambda/src/main/java/RefreshPatientList.java
+++ b/link-lambda/src/main/java/RefreshPatientList.java
@@ -4,6 +4,20 @@ import com.amazonaws.services.lambda.runtime.RequestHandler;
 public class RefreshPatientList implements RequestHandler<Void,String> {
     @Override
     public String handleRequest(Void unused, Context context) {
-        return "";
+        String returnValue = "";
+
+        try {
+
+            // Read API Auth from Secrets
+
+            // Read EPIC Query information from Secrets
+
+            // Read RefreshPatientList configuration from Secrets
+
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+
+        return returnValue;
     }
 }

--- a/link-lambda/src/main/java/RefreshPatientList.java
+++ b/link-lambda/src/main/java/RefreshPatientList.java
@@ -1,23 +1,96 @@
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.lantanagroup.link.config.auth.LinkOAuthConfig;
+import com.lantanagroup.link.config.query.QueryConfig;
+import com.lantanagroup.link.query.auth.EpicAuthConfig;
+import com.lantanagroup.link.tasks.RefreshPatientListTask;
+import com.lantanagroup.link.tasks.config.CensusReportingPeriods;
+import com.lantanagroup.link.tasks.config.RefreshPatientListConfig;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.regions.Region;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class RefreshPatientList implements RequestHandler<Void,String> {
+
+    private static final Logger logger = LoggerFactory.getLogger(RefreshPatientList.class);
     @Override
     public String handleRequest(Void unused, Context context) {
         String returnValue = "";
 
         try {
 
-            // Read API Auth from Secrets
+            logger.info("RefreshPatientList Lambda - Started");
+
+            String apiAuthSecretName = System.getenv("API_AUTH_SECRET"); // dev-thsa-link-api-authentication
+            Region region = Region.of(System.getenv("AWS_REGION"));
+            String apiUrl = System.getenv("API_ENDPOINT");
+            String epicQuerySecretName = System.getenv("PARKLAND_EPIC_QUERY_SECRET"); // dev-thsa-link-parkland-epic-query
+            String epicAuthSecretName = System.getenv("PARKLAND_EPIC_AUTH_SECRET"); // dev-thsa-link-parkland-epic-auth
+            String refreshPatientListSecret = System.getenv("PARKLAND_REFRESH_PATIENT_SECRET"); // dev-thsa-link-parkland-refresh-patient-list
+            logger.info("Environment Variables Read");
+
+            LinkOAuthConfig authConfig = Utility.GetLinkOAuthConfigFromAwsSecrets(region, apiAuthSecretName);
+            logger.info("LinkOAuthConfig Created");
 
             // Read EPIC Query information from Secrets
+            QueryConfig queryConfig = Utility.GetQueryConfigFromAwsSecrets(region, epicQuerySecretName);
+
+            // Read EPIC Authentication information from Secrets
+            EpicAuthConfig epicAuthConfig = Utility.GetEpicAuthConfigFromAwsSecrets(region, epicAuthSecretName);
 
             // Read RefreshPatientList configuration from Secrets
+            RefreshPatientListConfig config = GetRefreshPatientListconfigFromAwsSecrets(region, refreshPatientListSecret);
+            config.setApiUrl(apiUrl);
+            config.setAuth(authConfig);
+
+            RefreshPatientListTask.RunRefreshPatientList(config, queryConfig, epicAuthConfig);
+
+            logger.info("RefreshPatientList Lambda - Completed");
 
         } catch (Exception ex) {
+            logger.error(ex.getMessage());
             throw new RuntimeException(ex);
         }
 
         return returnValue;
+    }
+
+    private RefreshPatientListConfig GetRefreshPatientListconfigFromAwsSecrets(Region region, String secretName) {
+        RefreshPatientListConfig config = new RefreshPatientListConfig();
+
+        JSONObject secretObject = Utility.GetAwsSecretAsJson(region, secretName);
+
+        config.setFhirServerBase(secretObject.getString("fhir-server-base"));
+        config.setCensusReportingPeriod(CensusReportingPeriods.valueOf(secretObject.getString("census-reporting-period")));
+
+        JSONArray patientListsArray = secretObject.getJSONArray("patient-list");
+
+        List<RefreshPatientListConfig.PatientList> patientLists = new ArrayList<>();
+        for (Object listObject : patientListsArray) {
+            if (listObject instanceof JSONObject) {
+                JSONObject patientListObject = (JSONObject) listObject;
+
+                RefreshPatientListConfig.PatientList list = new RefreshPatientListConfig.PatientList();
+                list.setPatientListPath(patientListObject.getString("patient-list-path"));
+
+                List<String> censusIdentifiers = new ArrayList<>();
+                for (Object censusObject : patientListObject.getJSONArray("census-identifier")) {
+                    if (censusObject instanceof String) {
+                        censusIdentifiers.add(censusObject.toString());
+                    }
+                }
+                list.setCensusIdentifier(censusIdentifiers);
+                patientLists.add(list);
+            }
+        }
+
+        config.setPatientList(patientLists);
+
+        return config;
     }
 }

--- a/link-lambda/src/main/java/Utility.java
+++ b/link-lambda/src/main/java/Utility.java
@@ -1,5 +1,7 @@
 import com.amazonaws.services.lambda.runtime.LambdaLogger;
 import com.lantanagroup.link.config.auth.LinkOAuthConfig;
+import com.lantanagroup.link.config.query.QueryConfig;
+import com.lantanagroup.link.query.auth.EpicAuthConfig;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
@@ -67,6 +69,30 @@ public class Utility {
         authConfig.setPassword(secretObject.getString("password"));
         authConfig.setScope(secretObject.getString("scope"));
         authConfig.setCredentialMode(secretObject.getString("credential-mode"));
+
+        return authConfig;
+    }
+
+    public static QueryConfig GetQueryConfigFromAwsSecrets(Region region, String secretName) {
+        QueryConfig queryConfig = new QueryConfig();
+
+        JSONObject secretObject = GetAwsSecretAsJson(region, secretName);
+
+        queryConfig.setQueryClass(secretObject.getString("query-class"));
+        queryConfig.setAuthClass(secretObject.getString("auth-class"));
+
+        return queryConfig;
+    }
+
+    public static EpicAuthConfig GetEpicAuthConfigFromAwsSecrets(Region region, String secretName) {
+        EpicAuthConfig authConfig = new EpicAuthConfig();
+
+        JSONObject secretObject = GetAwsSecretAsJson(region, secretName);
+
+        authConfig.setAudience(secretObject.getString("audience"));
+        authConfig.setKey(secretObject.getString("key"));
+        authConfig.setClientId(secretObject.getString("client-id"));
+        authConfig.setTokenUrl(secretObject.getString("token-url"));
 
         return authConfig;
     }

--- a/link-lambda/src/main/java/Utility.java
+++ b/link-lambda/src/main/java/Utility.java
@@ -1,4 +1,5 @@
 import com.amazonaws.services.lambda.runtime.LambdaLogger;
+import com.lantanagroup.link.config.auth.LinkOAuthConfig;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
@@ -52,5 +53,21 @@ public class Utility {
 
         return new JSONObject(secret);
 
+    }
+
+    public static LinkOAuthConfig GetLinkOAuthConfigFromAwsSecrets(Region region, String secretName) {
+        LinkOAuthConfig authConfig = new LinkOAuthConfig();
+
+        JSONObject secretObject = GetAwsSecretAsJson(region, secretName);
+
+        authConfig.setTokenUrl(secretObject.getString("token-url"));
+        authConfig.setClientId(secretObject.getString("client-id"));
+        authConfig.setClientSecret(secretObject.getString("client-secret"));
+        authConfig.setUsername(secretObject.getString("username"));
+        authConfig.setPassword(secretObject.getString("password"));
+        authConfig.setScope(secretObject.getString("scope"));
+        authConfig.setCredentialMode(secretObject.getString("credential-mode"));
+
+        return authConfig;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -39,8 +39,8 @@
         <module>thsa</module>
         <module>nhsn</module>
         <module>mhl</module>
-        <module>link-lambda</module>
         <module>tasks</module>
+        <module>link-lambda</module>
     </modules>
 
     <dependencies>

--- a/query/src/main/java/com/lantanagroup/link/query/auth/AzureAuth.java
+++ b/query/src/main/java/com/lantanagroup/link/query/auth/AzureAuth.java
@@ -18,6 +18,11 @@ public class AzureAuth implements ICustomAuth {
   private AzureAuthConfig config;
 
   @Override
+  public void setConfig(ICustomAuthConfig authConfig) throws Exception {
+    config = (AzureAuthConfig) authConfig;
+  }
+
+  @Override
   public String getAuthHeader() throws Exception {
     String requestBody = String.format(
             "grant_type=client_credentials&client_id=%s&client_secret=%s&resource=%s",

--- a/query/src/main/java/com/lantanagroup/link/query/auth/AzureAuthConfig.java
+++ b/query/src/main/java/com/lantanagroup/link/query/auth/AzureAuthConfig.java
@@ -12,7 +12,7 @@ import org.springframework.context.annotation.PropertySource;
 @Configuration
 @ConfigurationProperties(prefix = "query.auth.azure")
 @PropertySource(value = "classpath:application.yml", factory = YamlPropertySourceFactory.class)
-public class AzureAuthConfig {
+public class AzureAuthConfig implements ICustomAuthConfig {
   private String tokenUrl;
   private String clientId;
   private String secret;

--- a/query/src/main/java/com/lantanagroup/link/query/auth/BasicAuth.java
+++ b/query/src/main/java/com/lantanagroup/link/query/auth/BasicAuth.java
@@ -12,6 +12,11 @@ public class BasicAuth implements ICustomAuth {
   private BasicAuthConfig config;
 
   @Override
+  public void setConfig(ICustomAuthConfig authConfig) throws Exception {
+    config = (BasicAuthConfig) authConfig;
+  }
+
+  @Override
   public String getAuthHeader() {
     String username = this.config.getUsername();
     String password = this.config.getPassword();

--- a/query/src/main/java/com/lantanagroup/link/query/auth/BasicAuthAndApiKeyHeader.java
+++ b/query/src/main/java/com/lantanagroup/link/query/auth/BasicAuthAndApiKeyHeader.java
@@ -14,6 +14,11 @@ public class BasicAuthAndApiKeyHeader implements ICustomAuth{
   private BasicAuthAndApiKeyHeaderConfig config;
 
   @Override
+  public void setConfig(ICustomAuthConfig authConfig) throws Exception {
+    config = (BasicAuthAndApiKeyHeaderConfig) authConfig;
+  }
+
+  @Override
   public String getAuthHeader() {
     String username = this.config.getUsername();
     String password = this.config.getPassword();

--- a/query/src/main/java/com/lantanagroup/link/query/auth/BasicAuthAndApiKeyHeaderConfig.java
+++ b/query/src/main/java/com/lantanagroup/link/query/auth/BasicAuthAndApiKeyHeaderConfig.java
@@ -12,7 +12,7 @@ import org.springframework.context.annotation.PropertySource;
 @Configuration
 @ConfigurationProperties(prefix = "query.auth.basicapikey")
 @PropertySource(value = "classpath:application.yml", factory = YamlPropertySourceFactory.class)
-public class BasicAuthAndApiKeyHeaderConfig {
+public class BasicAuthAndApiKeyHeaderConfig implements ICustomAuthConfig {
   private String username;
   private String password;
   private String apikey;

--- a/query/src/main/java/com/lantanagroup/link/query/auth/BasicAuthConfig.java
+++ b/query/src/main/java/com/lantanagroup/link/query/auth/BasicAuthConfig.java
@@ -12,7 +12,7 @@ import org.springframework.context.annotation.PropertySource;
 @Configuration
 @ConfigurationProperties(prefix = "query.auth.basic")
 @PropertySource(value = "classpath:application.yml", factory = YamlPropertySourceFactory.class)
-public class BasicAuthConfig {
+public class BasicAuthConfig implements ICustomAuthConfig {
   private String username;
   private String password;
 }

--- a/query/src/main/java/com/lantanagroup/link/query/auth/CernerAuth.java
+++ b/query/src/main/java/com/lantanagroup/link/query/auth/CernerAuth.java
@@ -15,6 +15,11 @@ public class CernerAuth implements ICustomAuth {
   private CernerAuthConfig config;
 
   @Override
+  public void setConfig(ICustomAuthConfig authConfig) throws Exception {
+    config = (CernerAuthConfig) authConfig;
+  }
+
+  @Override
   public String getAuthHeader() {
     logger.debug("Using OAuth2 to retrieve a system token for FHIR authentication");
     String token = OAuth2Helper.getClientCredentialsToken(

--- a/query/src/main/java/com/lantanagroup/link/query/auth/CernerAuthConfig.java
+++ b/query/src/main/java/com/lantanagroup/link/query/auth/CernerAuthConfig.java
@@ -11,7 +11,7 @@ import org.springframework.context.annotation.PropertySource;
 @Configuration
 @ConfigurationProperties(prefix = "query.auth.cerner")
 @PropertySource(value = "classpath:application.yml", factory = YamlPropertySourceFactory.class)
-public class CernerAuthConfig {
+public class CernerAuthConfig implements ICustomAuthConfig {
   private String tokenUrl;
   private String clientId;
   private String secret;

--- a/query/src/main/java/com/lantanagroup/link/query/auth/EpicAuth.java
+++ b/query/src/main/java/com/lantanagroup/link/query/auth/EpicAuth.java
@@ -62,6 +62,11 @@ public class EpicAuth implements ICustomAuth {
   }
 
   @Override
+  public void setConfig(ICustomAuthConfig authConfig) throws Exception {
+    config = (EpicAuthConfig) authConfig;
+  }
+
+  @Override
   public String getAuthHeader() throws URISyntaxException {
     logger.debug("Generating JWT to request auth token from Epic");
 

--- a/query/src/main/java/com/lantanagroup/link/query/auth/EpicAuthConfig.java
+++ b/query/src/main/java/com/lantanagroup/link/query/auth/EpicAuthConfig.java
@@ -12,7 +12,7 @@ import org.springframework.context.annotation.PropertySource;
 @Configuration
 @ConfigurationProperties(prefix = "query.auth.epic")
 @PropertySource(value = "classpath:application.yml", factory = YamlPropertySourceFactory.class)
-public class EpicAuthConfig {
+public class EpicAuthConfig implements ICustomAuthConfig {
   private String key;
   private String tokenUrl;
   private String clientId;

--- a/query/src/main/java/com/lantanagroup/link/query/auth/ICustomAuth.java
+++ b/query/src/main/java/com/lantanagroup/link/query/auth/ICustomAuth.java
@@ -1,6 +1,7 @@
 package com.lantanagroup.link.query.auth;
 
 public interface ICustomAuth {
+  void setConfig(ICustomAuthConfig authConfig) throws Exception;
   String getAuthHeader() throws Exception;
   String getApiKeyHeader() throws Exception;
 }

--- a/query/src/main/java/com/lantanagroup/link/query/auth/ICustomAuthConfig.java
+++ b/query/src/main/java/com/lantanagroup/link/query/auth/ICustomAuthConfig.java
@@ -1,0 +1,4 @@
+package com.lantanagroup.link.query.auth;
+
+public interface ICustomAuthConfig {
+}

--- a/query/src/main/java/com/lantanagroup/link/query/auth/TokenAuth.java
+++ b/query/src/main/java/com/lantanagroup/link/query/auth/TokenAuth.java
@@ -11,6 +11,11 @@ public class TokenAuth implements ICustomAuth {
   private TokenAuthConfig config;
 
   @Override
+  public void setConfig(ICustomAuthConfig authConfig) throws Exception {
+    config = (TokenAuthConfig) authConfig;
+  }
+
+  @Override
   public String getAuthHeader() {
     return this.config.getToken();
   }

--- a/query/src/main/java/com/lantanagroup/link/query/auth/TokenAuthConfig.java
+++ b/query/src/main/java/com/lantanagroup/link/query/auth/TokenAuthConfig.java
@@ -12,6 +12,6 @@ import org.springframework.context.annotation.PropertySource;
 @Configuration
 @ConfigurationProperties(prefix = "query.auth.token")
 @PropertySource(value = "classpath:application.yml", factory = YamlPropertySourceFactory.class)
-public class TokenAuthConfig {
+public class TokenAuthConfig implements ICustomAuthConfig {
   private String token;
 }

--- a/tasks/src/main/java/com/lantanagroup/link/tasks/ExpungeDataTask.java
+++ b/tasks/src/main/java/com/lantanagroup/link/tasks/ExpungeDataTask.java
@@ -22,7 +22,7 @@ public class ExpungeDataTask {
             throw new Exception("Issue with expunge-data configuration");
         }
 
-        String url = config.getApiUrl() + "/data/expunge";
+        String url = config.getApiUrl();
         logger.info("Calling API Expunge Data at {}", url);
 
         try {

--- a/tasks/src/main/java/com/lantanagroup/link/tasks/RefreshPatientListTask.java
+++ b/tasks/src/main/java/com/lantanagroup/link/tasks/RefreshPatientListTask.java
@@ -37,6 +37,8 @@ public class RefreshPatientListTask {
     private QueryConfig queryConfig;
 
     public void RunRefreshPatientList(RefreshPatientListConfig config, QueryConfig queryConfig, ApplicationContext applicationContext) {
+        // Read API Auth From Secrets
+
         // Read Query Config From Secrets
 
         // Read RefreshPatientListConfig from Secrets

--- a/terraform/components/cli-refresh-patient-list.tf
+++ b/terraform/components/cli-refresh-patient-list.tf
@@ -1,62 +1,62 @@
-module "ecs-task-refresh-patient-list" {
-  source = "../modules/ecs-task-cli"
-
-  application_code = "refresh-patient-list"
-
-  aws_region = var.aws_region
-  aws_profile = var.aws_profile
-  environment = var.environment
-  customer = var.customer
-  project_code = var.project_code
-
-  # TFVARS
-  image_repository = var.docker_image_repository
-  image_name = "thsa-link-cli-refresh-patient-list"
-  image_tag = var.default_docker_tag
-  ecs_task_role = data.terraform_remote_state.infra.outputs.iam-role-arn
-
-  container_environment_file = jsonencode([])
-  container_environment = jsonencode([])
-
-  cpu_size = var.default_cpu_size
-  memory_size = var.default_memory_size
-
-  mount_points = jsonencode([{
-    sourceVolume: "cli",
-    containerPath: "/cli",
-    readOnly: false
-  }])
-
-  volume_filesystem_id = data.terraform_remote_state.infra.outputs.file-system.id
-  volume_name = "cli"
-  volume_root_directory = "/cli"
-}
-
-resource "aws_scheduler_schedule" "refresh-patient-list-schedule" {
-  name = "${var.environment}-${var.customer}-${var.project_code}-refresh-patient-list"
-  group_name = "default"
-
-  flexible_time_window {
-    mode = "OFF"
-  }
-
-  schedule_expression = "cron(0 13,1 ? * * *)"
-
-  target {
-    arn      = data.terraform_remote_state.infra.outputs.ecs_cluster_arn
-    role_arn = aws_iam_role.scheduler-role.arn
-    ecs_parameters {
-      task_definition_arn = module.ecs-task-refresh-patient-list.arn
-      task_count = "1"
-      launch_type = "FARGATE"
-      network_configuration {
-        subnets = var.subnets
-        security_groups = var.security_groups
-        assign_public_ip = false
-      }
-      platform_version = "LATEST"
-      enable_execute_command = false
-      enable_ecs_managed_tags = true
-    }
-  }
-}
+#module "ecs-task-refresh-patient-list" {
+#  source = "../modules/ecs-task-cli"
+#
+#  application_code = "refresh-patient-list"
+#
+#  aws_region = var.aws_region
+#  aws_profile = var.aws_profile
+#  environment = var.environment
+#  customer = var.customer
+#  project_code = var.project_code
+#
+#  # TFVARS
+#  image_repository = var.docker_image_repository
+#  image_name = "thsa-link-cli-refresh-patient-list"
+#  image_tag = var.default_docker_tag
+#  ecs_task_role = data.terraform_remote_state.infra.outputs.iam-role-arn
+#
+#  container_environment_file = jsonencode([])
+#  container_environment = jsonencode([])
+#
+#  cpu_size = var.default_cpu_size
+#  memory_size = var.default_memory_size
+#
+#  mount_points = jsonencode([{
+#    sourceVolume: "cli",
+#    containerPath: "/cli",
+#    readOnly: false
+#  }])
+#
+#  volume_filesystem_id = data.terraform_remote_state.infra.outputs.file-system.id
+#  volume_name = "cli"
+#  volume_root_directory = "/cli"
+#}
+#
+#resource "aws_scheduler_schedule" "refresh-patient-list-schedule" {
+#  name = "${var.environment}-${var.customer}-${var.project_code}-refresh-patient-list"
+#  group_name = "default"
+#
+#  flexible_time_window {
+#    mode = "OFF"
+#  }
+#
+#  schedule_expression = "cron(0 13,1 ? * * *)"
+#
+#  target {
+#    arn      = data.terraform_remote_state.infra.outputs.ecs_cluster_arn
+#    role_arn = aws_iam_role.scheduler-role.arn
+#    ecs_parameters {
+#      task_definition_arn = module.ecs-task-refresh-patient-list.arn
+#      task_count = "1"
+#      launch_type = "FARGATE"
+#      network_configuration {
+#        subnets = var.subnets
+#        security_groups = var.security_groups
+#        assign_public_ip = false
+#      }
+#      platform_version = "LATEST"
+#      enable_execute_command = false
+#      enable_ecs_managed_tags = true
+#    }
+#  }
+#}

--- a/terraform/components/lambda-expunge-data.tf
+++ b/terraform/components/lambda-expunge-data.tf
@@ -124,8 +124,8 @@ resource "aws_lambda_function" "expunge-data" {
 
   environment {
     variables = {
-      EXPUNGE_API_URL = "https://thsa1.sanerproject.org:10440/api/data/expunge"
-      SECRET_NAME = aws_secretsmanager_secret.expunge-data.name
+      API_ENDPOINT = "https://thsa1.sanerproject.org:10440/api/data/expunge"
+      API_AUTH_SECRET = aws_secretsmanager_secret.expunge-data.name
     }
   }
 }

--- a/terraform/components/lambda-refresh-patient-list.tf
+++ b/terraform/components/lambda-refresh-patient-list.tf
@@ -1,0 +1,164 @@
+resource "aws_iam_role" "refresh-patient-list" {
+  max_session_duration = "3600"
+  name = "${var.environment}-${var.customer}-${var.project_code}-refresh-patient-list-lambda"
+  path = "/service-role/"
+
+  assume_role_policy = jsonencode({
+    "Statement": [
+      {
+        "Action": "sts:AssumeRole",
+        "Effect": "Allow",
+        "Principal": {
+          "Service": "lambda.amazonaws.com"
+        }
+      }
+    ],
+    "Version": "2012-10-17"
+  })
+
+  inline_policy {
+    name = "ReadExpungeSecret"
+    policy = jsonencode({
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": [
+            "secretsmanager:GetSecretValue",
+            "secretsmanager:DescribeSecret"
+          ],
+          "Effect": "Allow",
+          "Resource": [
+            aws_secretsmanager_secret.api-authentication.arn,
+            aws_secretsmanager_secret.parkland-epic-auth.arn,
+            aws_secretsmanager_secret.parkland-epic-query.arn,
+            aws_secretsmanager_secret.parkland-refresh-patient-list.arn
+          ]
+          "Sid": "VisualEditor0"
+        }
+      ]
+    })
+  }
+
+  // TODO - name the actual lambda in resource - getting cyclical error currently.
+  inline_policy {
+    name = "CreateLogGroup"
+    policy = jsonencode({
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Action": "logs:CreateLogGroup",
+          "Resource": "arn:aws:logs:us-east-1:${var.aws_account}:*"
+        },
+        {
+          "Effect": "Allow",
+          "Action": [
+            "logs:CreateLogStream",
+            "logs:PutLogEvents"
+          ],
+          "Resource": [
+            "arn:aws:logs:us-east-1:${var.aws_account}:log-group:/aws/lambda/*"
+          ]
+        }
+      ]
+    })
+  }
+}
+
+resource "aws_iam_role" "refresh-patient-list-lambda-scheduler-role" {
+  name = "${var.environment}-${var.customer}-${var.project_code}-refresh-patient-list-scheduler-role"
+  assume_role_policy = jsonencode({
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Principal": {
+          "Service": "scheduler.amazonaws.com"
+        },
+        "Action": "sts:AssumeRole",
+        "Condition": {
+          "StringEquals": {
+            "aws:SourceAccount": var.aws_account
+          }
+        }
+      }
+    ]
+  })
+
+  max_session_duration = "3600"
+
+  inline_policy {
+    name = "${var.environment}-${var.customer}-${var.project_code}-RunLambda"
+    policy = jsonencode({
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Action": [
+            "lambda:InvokeFunction"
+          ],
+          "Resource": [
+            "arn:aws:lambda:us-east-1:${var.aws_account}:function:${aws_lambda_function.refresh-patient-list.function_name}:*",
+            "arn:aws:lambda:us-east-1:${var.aws_account}:function:${aws_lambda_function.refresh-patient-list.function_name}"
+          ]
+        }
+      ]
+    })
+  }
+  tags = {
+    Environment = var.environment,
+    CreatedBy = "terraform"
+  }
+}
+
+resource "aws_lambda_function" "refresh-patient-list" {
+
+  function_name = "${var.environment}-${var.customer}-${var.project_code}-refresh-patient-list"
+  role = aws_iam_role.refresh-patient-list.arn
+  handler = "RefreshPatientList"
+  runtime = "java17"
+  timeout = 300
+  s3_bucket = data.terraform_remote_state.infra.outputs.lambda_deploy_bucket.bucket
+  s3_key = module.lambda-jar.s3-file.key
+  s3_object_version = module.lambda-jar.s3-file.version_id
+
+  tags = {
+    Environment = var.environment,
+    CreatedBy = "terraform"
+  }
+
+  environment {
+    variables = {
+      API_AUTH_SECRET = aws_secretsmanager_secret.api-authentication.name
+      API_ENDPOINT = "https://thsa1.sanerproject.org:10440/api/poi/fhir/PatientList"
+      PARKLAND_EPIC_AUTH_SECRET = aws_secretsmanager_secret.parkland-epic-auth.name
+      PARKLAND_EPIC_QUERY_SECRET = aws_secretsmanager_secret.parkland-epic-query.name
+      PARKLAND_REFRESH_PATIENT_SECRET = aws_secretsmanager_secret.parkland-refresh-patient-list.name
+    }
+  }
+}
+
+resource "aws_scheduler_schedule" "refresh-patient-list" {
+  name = "${var.environment}-${var.customer}-${var.project_code}-refresh-patient-list-lambda"
+  group_name = "default"
+
+  flexible_time_window {
+    mode = "OFF"
+  }
+
+  schedule_expression = "cron(0 13,1 ? * * *)"
+
+  target {
+    arn      = aws_lambda_function.refresh-patient-list.arn
+    role_arn = aws_iam_role.refresh-patient-list-lambda-scheduler-role.arn
+    input = jsonencode({})
+  }
+}
+
+
+resource "aws_lambda_permission" "refresh-patient-list" {
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.refresh-patient-list.function_name
+  principal     = "events.amazonaws.com"
+  source_arn = aws_scheduler_schedule.refresh-patient-list.arn
+}

--- a/terraform/components/scheduler-role.tf
+++ b/terraform/components/scheduler-role.tf
@@ -55,24 +55,6 @@ resource "aws_iam_role" "scheduler-role" {
     })
   }
 
-  inline_policy {
-    name = "${var.environment}-${var.customer}-${var.project_code}-RunLambda"
-    policy = jsonencode({
-      "Version": "2012-10-17",
-      "Statement": [
-        {
-          "Effect": "Allow",
-          "Action": [
-            "lambda:InvokeFunction"
-          ],
-          "Resource": [
-            "arn:aws:lambda:us-east-1:${var.aws_account}:function:${aws_lambda_function.expunge-data.function_name}:*",
-            "arn:aws:lambda:us-east-1:${var.aws_account}:function:${aws_lambda_function.expunge-data.function_name}"
-          ]
-        }
-      ]
-    })
-  }
   tags = {
     Environment = var.environment,
     CreatedBy = "terraform"

--- a/terraform/components/secrets.tf
+++ b/terraform/components/secrets.tf
@@ -39,3 +39,45 @@ resource "aws_secretsmanager_secret_version" "parkland-sftp" {
   secret_id = aws_secretsmanager_secret.parkland-sftp.id
   secret_string = file("../environment-files/secrets/parkland-sftp.json")
 }
+
+# Parkland EPIC Query Configuration
+resource "aws_secretsmanager_secret" "parkland-epic-query" {
+  name = "${var.environment}-${var.customer}-${var.project_code}-parkland-epic-query"
+  tags = {
+    Environment = var.environment,
+    CreatedBy = "terraform"
+  }
+}
+
+resource "aws_secretsmanager_secret_version" "parkland-epic-query" {
+  secret_id = aws_secretsmanager_secret.parkland-epic-query.id
+  secret_string = file("../environment-files/secrets/parkland-epic-query.json")
+}
+
+# Parkland EPIC Authentication Configuration
+resource "aws_secretsmanager_secret" "parkland-epic-auth" {
+  name = "${var.environment}-${var.customer}-${var.project_code}-parkland-epic-auth"
+  tags = {
+    Environment = var.environment,
+    CreatedBy = "terraform"
+  }
+}
+
+resource "aws_secretsmanager_secret_version" "parkland-epic-auth" {
+  secret_id = aws_secretsmanager_secret.parkland-epic-auth.id
+  secret_string = file("../environment-files/secrets/parkland-epic-authentication.json")
+}
+
+# Parkland Refresh Patient List
+resource "aws_secretsmanager_secret" "parkland-refresh-patient-list" {
+  name = "${var.environment}-${var.customer}-${var.project_code}-parkland-refresh-patient-list"
+  tags = {
+    Environment = var.environment,
+    CreatedBy = "terraform"
+  }
+}
+
+resource "aws_secretsmanager_secret_version" "parkland-refresh-patient-list" {
+  secret_id = aws_secretsmanager_secret.parkland-refresh-patient-list.id
+  secret_string = file("../environment-files/secrets/parkland-refresh-patient-list.json")
+}

--- a/terraform/modules/ecs-service/ecs-service.tf
+++ b/terraform/modules/ecs-service/ecs-service.tf
@@ -53,6 +53,15 @@ resource "aws_ecs_service" "ecs_service" {
                     port = var.container_port
                 }
             }
+            log_configuration {
+                log_driver = "awslogs"
+                options = {
+                    awslogs-group = "/ecs-serviceconnect/"
+                    awslogs-region = var.aws_region
+                    awslogs-create-group = true
+                    awslogs-stream-prefix = "${var.environment}-${var.customer}-${var.project_code}-${var.application_code}"
+                }
+            }
         }
     }
     tags = {


### PR DESCRIPTION
- ExpungeData lambda setup to use environment fields API_ENDPOINT and API_AUTH_SECRET to match what was setup for ParklandInventoryImport (and will be used going forwarded)
- Updated terraform associated with ExpungeData lambda for those environment field names.
- ExpungeDataTask now uses url specified in the ExpungeDataConfig to connect to the API.  Previous the url up to /api was specified and the code added the end.  Going forward in code will assume the entire url has been specified.
- RefreshPatientList now available to run as Lambda.  Created terraform.