### PR TITLE
THSALINK-024

### DIFF
--- a/cli/src/main/java/com/lantanagroup/link/cli/SendReports.java
+++ b/cli/src/main/java/com/lantanagroup/link/cli/SendReports.java
@@ -1,0 +1,31 @@
+package com.lantanagroup.link.cli;
+
+import com.lantanagroup.link.tasks.SendReportsTask;
+import com.lantanagroup.link.tasks.config.SendReportsConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.shell.standard.ShellComponent;
+import org.springframework.shell.standard.ShellMethod;
+
+@ShellComponent
+public class SendReports extends BaseShellCommand {
+    private static final Logger logger = LoggerFactory.getLogger(SendReports.class);
+
+    @ShellMethod(key = "send-reports", value = "Finds reports that have not been sent and sends them.")
+    public void execute() {
+        try {
+            logger.info("SendReports - CLI - Started");
+            registerBeans();
+            SendReportsConfig config = applicationContext.getBean(SendReportsConfig.class);
+
+            SendReportsTask.executeTask(config);
+
+            logger.info("SendReports - CLI - Completed");
+        } catch (Exception ex) {
+            logger.error("Issue with SendReports CLI - {}", ex.getMessage());
+            System.exit(1);
+        }
+
+        System.exit(0);
+    }
+}

--- a/cli/src/main/java/com/lantanagroup/link/cli/SingleCommandShellRunner.java
+++ b/cli/src/main/java/com/lantanagroup/link/cli/SingleCommandShellRunner.java
@@ -24,6 +24,7 @@ public class SingleCommandShellRunner implements ApplicationRunner {
           "expunge-data",
           "manual-expunge",
           "generate-report",
+          "send-reports",
           "austin-tester");
 
   public SingleCommandShellRunner(Shell shell, ConfigurableEnvironment environment) {

--- a/core/src/main/java/com/lantanagroup/link/Constants.java
+++ b/core/src/main/java/com/lantanagroup/link/Constants.java
@@ -51,4 +51,6 @@ public class Constants {
   public static final Coding GENERATE_REPORT = new Coding().setCode("generate-report").setSystem("https://nhsnlink.org").setDisplay("Generate Report Task");
   public static final Coding FILE_UPLOAD = new Coding().setCode("file-upload").setSystem("https://nhsnlink.org").setDisplay("Upload Data File");
   public static final Coding EXTERNAL_FILE_DOWNLOAD = new Coding().setCode("external-file-download").setSystem("https://nhsnlink.org").setDisplay("File Downloaded From Source");
+  public static final Coding SEND_REPORT  = new Coding().setCode("send-report").setSystem("https://nhsnlink.org").setDisplay("Send Report Task");
+  public static final String DOCUMENT_REFERENCE_VERSION_URL = "https://www.cdc.gov/nhsn/fhir/nhsnlink/StructureDefinition/nhsnlink-report-version";
 }

--- a/core/src/main/java/com/lantanagroup/link/FhirHelper.java
+++ b/core/src/main/java/com/lantanagroup/link/FhirHelper.java
@@ -30,7 +30,7 @@ public class FhirHelper {
   private static final Logger logger = LoggerFactory.getLogger(FhirHelper.class);
   private static final String NAME = "name";
   private static final String SUBJECT = "sub";
-  private static final String DOCUMENT_REFERENCE_VERSION_URL = "https://www.cdc.gov/nhsn/fhir/nhsnlink/StructureDefinition/nhsnlink-report-version";
+  //private static final String DOCUMENT_REFERENCE_VERSION_URL = "https://www.cdc.gov/nhsn/fhir/nhsnlink/StructureDefinition/nhsnlink-report-version";
 
   public static void recordAuditEvent(HttpServletRequest request, FhirDataProvider fhirDataProvider, DecodedJWT jwt, AuditEventTypes type, String outcomeDescription) {
     AuditEvent auditEvent = createAuditEvent(request, jwt, type, outcomeDescription);
@@ -171,7 +171,7 @@ public class FhirHelper {
   }
 
   public static Extension createVersionExtension(String value) {
-    return new Extension(DOCUMENT_REFERENCE_VERSION_URL, new StringType(value));
+    return new Extension(Constants.DOCUMENT_REFERENCE_VERSION_URL, new StringType(value));
   }
 
   /**
@@ -182,14 +182,14 @@ public class FhirHelper {
    */
   public static DocumentReference incrementMinorVersion(DocumentReference documentReference) {
 
-    if (documentReference.getExtensionByUrl(DOCUMENT_REFERENCE_VERSION_URL) == null) {
+    if (documentReference.getExtensionByUrl(Constants.DOCUMENT_REFERENCE_VERSION_URL) == null) {
       documentReference.addExtension(createVersionExtension("0.1"));
     } else {
       String version = documentReference
-              .getExtensionByUrl(DOCUMENT_REFERENCE_VERSION_URL)
+              .getExtensionByUrl(Constants.DOCUMENT_REFERENCE_VERSION_URL)
               .getValue().toString();
 
-      documentReference.getExtensionByUrl(DOCUMENT_REFERENCE_VERSION_URL)
+      documentReference.getExtensionByUrl(Constants.DOCUMENT_REFERENCE_VERSION_URL)
               .setValue(new StringType(version.substring(0, version.indexOf(".") + 1) + (Integer.parseInt(version.substring(version.indexOf(".") + 1)) + 1)));
     }
 
@@ -201,15 +201,15 @@ public class FhirHelper {
    * @return - the DocumentReference with the major version incremented by 1
    */
   public static DocumentReference incrementMajorVersion(DocumentReference documentReference) {
-    if (documentReference.getExtensionByUrl(DOCUMENT_REFERENCE_VERSION_URL) == null) {
+    if (documentReference.getExtensionByUrl(Constants.DOCUMENT_REFERENCE_VERSION_URL) == null) {
       documentReference.addExtension(createVersionExtension("1.0"));
     } else {
       String version = documentReference
-              .getExtensionByUrl(DOCUMENT_REFERENCE_VERSION_URL)
+              .getExtensionByUrl(Constants.DOCUMENT_REFERENCE_VERSION_URL)
               .getValue().toString();
 
       version = version.substring(0, version.indexOf("."));
-      documentReference.getExtensionByUrl(DOCUMENT_REFERENCE_VERSION_URL)
+      documentReference.getExtensionByUrl(Constants.DOCUMENT_REFERENCE_VERSION_URL)
               .setValue(new StringType((Integer.parseInt(version) + 1) + ".0"));
     }
     return documentReference;
@@ -501,7 +501,7 @@ public class FhirHelper {
   public static void setSubmissionLocation(DocumentReference documentReference, String location) {
     documentReference.getContent().removeIf(c -> c.hasAttachment() && c.getAttachment().hasUrl());
     DocumentReference.DocumentReferenceContentComponent newContent = new DocumentReference.DocumentReferenceContentComponent();
-    newContent.getAttachment().setUrl(location);
+    newContent.getAttachment().setUrl(location).setCreation(new Date()).setTitle("SubmissionLocation");
     documentReference.getContent().add(newContent);
   }
 

--- a/core/src/main/java/com/lantanagroup/link/GenericSender.java
+++ b/core/src/main/java/com/lantanagroup/link/GenericSender.java
@@ -90,7 +90,7 @@ public abstract class GenericSender {
       return locations.get(0);
     }
 
-    return null;
+    return "";
   }
 
   private String locationCleaner(String location) {

--- a/core/src/main/java/com/lantanagroup/link/IReportSender.java
+++ b/core/src/main/java/com/lantanagroup/link/IReportSender.java
@@ -1,16 +1,12 @@
 package com.lantanagroup.link;
 
-import ca.uhn.fhir.context.FhirContext;
-import com.lantanagroup.link.config.api.ApiConfig;
 import com.lantanagroup.link.config.bundler.BundlerConfig;
-import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.DocumentReference;
 import org.hl7.fhir.r4.model.MeasureReport;
-import org.springframework.security.core.Authentication;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.List;
 
 public interface IReportSender {
-  void send(List<MeasureReport> masterMeasureReports, DocumentReference documentReference, HttpServletRequest request, Authentication auth, FhirDataProvider fhirDataProvider, BundlerConfig bundlerConfig) throws Exception;
+  String send(List<MeasureReport> masterMeasureReports, DocumentReference documentReference, HttpServletRequest request, FhirDataProvider fhirDataProvider, BundlerConfig bundlerConfig) throws Exception;
 }

--- a/core/src/main/java/com/lantanagroup/link/config/datastore/DataStoreDaoConfig.java
+++ b/core/src/main/java/com/lantanagroup/link/config/datastore/DataStoreDaoConfig.java
@@ -32,4 +32,7 @@ public class DataStoreDaoConfig {
 
     @Getter
     private Boolean deleteExpungeEnabled;
+
+    @Getter
+    private Boolean filterParameterEnabled;
 }

--- a/core/src/main/java/com/lantanagroup/link/model/Report.java
+++ b/core/src/main/java/com/lantanagroup/link/model/Report.java
@@ -20,6 +20,7 @@ public class Report {
   Date creationDate;
   String submittedDate;
   String note;
+  String documentReferenceId;
   ReportMeasure reportMeasure;
 
   public Report (Bundle.BundleEntryComponent entry) {
@@ -46,6 +47,8 @@ public class Report {
     if (docReference.getDate() != null) {
       this.setSubmittedDate(Helper.getFhirDate(docReference.getDate()));
     }
+
+    this.setDocumentReferenceId(docReference.getIdElement().getIdPart());
 
     if (!docReference.getIdentifier().isEmpty()) {
       ReportMeasure rm = new ReportMeasure();

--- a/core/src/main/java/com/lantanagroup/link/model/Report.java
+++ b/core/src/main/java/com/lantanagroup/link/model/Report.java
@@ -23,6 +23,9 @@ public class Report {
   String documentReferenceId;
   ReportMeasure reportMeasure;
 
+  public Report() {
+  }
+
   public Report (Bundle.BundleEntryComponent entry) {
     DocumentReference docReference = (DocumentReference) entry.getResource();
     if (!docReference.getAuthor().isEmpty()) {

--- a/datastore/src/main/java/com/lantanagroup/link/datastore/DataStoreApplication.java
+++ b/datastore/src/main/java/com/lantanagroup/link/datastore/DataStoreApplication.java
@@ -76,6 +76,7 @@ public class DataStoreApplication extends SpringBootServletInitializer {
       if (dao.getAllowMultipleDelete() != null) { theDaoConfig.setDeleteExpungeEnabled(dao.getAllowMultipleDelete()); }
       if (dao.getFetchSizeDefaultMaximum() != null) { theDaoConfig.setFetchSizeDefaultMaximum(dao.getFetchSizeDefaultMaximum()); }
       if (dao.getExpireSearchResultsAfterMillis() != null) { theDaoConfig.setExpireSearchResultsAfterMillis(dao.getExpireSearchResultsAfterMillis()); }
+      if (dao.getFilterParameterEnabled() != null) { theDaoConfig.setFilterParameterEnabled(dao.getFilterParameterEnabled()); }
     }
 
     return theDaoConfig;

--- a/link-lambda/src/main/java/SendReports.java
+++ b/link-lambda/src/main/java/SendReports.java
@@ -1,0 +1,48 @@
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.lantanagroup.link.config.auth.LinkOAuthConfig;
+import com.lantanagroup.link.tasks.SendReportsTask;
+import com.lantanagroup.link.tasks.config.SendReportsConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.regions.Region;
+
+public class SendReports implements RequestHandler<Void,String> {
+
+    private static final Logger logger = LoggerFactory.getLogger(SendReports.class);
+    @Override
+    public String handleRequest(Void unused, Context context) {
+        String returnValue = "";
+
+        try {
+            logger.info("SendReports Lambda - Started");
+
+            String authSecretName = System.getenv("API_AUTH_SECRET");
+            Region region = Region.of(System.getenv("AWS_REGION"));
+            String searchReportsUrl = System.getenv("SEARCH_REPORTS_URL");
+            String sendReportUrl = System.getenv("SEND_REPORT_URL");
+            logger.info("Environment Variables Read");
+
+            LinkOAuthConfig authConfig = Utility.GetLinkOAuthConfigFromAwsSecrets(region, authSecretName);
+            logger.info("LinkOAuthConfig Created");
+
+            SendReportsConfig config = new SendReportsConfig();
+            config.setAuth(authConfig);
+            config.setSendReportUrl(sendReportUrl);
+            config.setSearchReportsUrl(searchReportsUrl);
+
+            logger.info("API Endpoint to search for reports: {}", config.getSearchReportsUrl());
+            logger.info("API Endpoint template to send reports: {}", config.getSendReportUrl());
+
+            logger.info("Calling SendReportsTask");
+            SendReportsTask.executeTask(config);
+
+            logger.info("SendReports Lambda - Completed");
+
+        } catch (Exception ex) {
+            logger.error(ex.getMessage());
+            throw new RuntimeException(ex);
+        }
+        return returnValue;
+    }
+}

--- a/nhsn/src/main/java/com/lantanagroup/link/nhsn/AzureBlobStorageSender.java
+++ b/nhsn/src/main/java/com/lantanagroup/link/nhsn/AzureBlobStorageSender.java
@@ -2,9 +2,8 @@ package com.lantanagroup.link.nhsn;
 
 import com.azure.core.util.BinaryData;
 import com.azure.storage.blob.*;
-import com.lantanagroup.link.*;
 import com.azure.storage.blob.models.ParallelTransferOptions;
-import com.lantanagroup.link.auth.LinkCredentials;
+import com.lantanagroup.link.*;
 import com.lantanagroup.link.config.api.ApiConfig;
 import com.lantanagroup.link.config.bundler.BundlerConfig;
 import com.lantanagroup.link.config.sender.AzureBlobStorageConfig;
@@ -17,7 +16,6 @@ import org.hl7.fhir.r4.model.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Flux;
 
@@ -207,10 +205,13 @@ public class AzureBlobStorageSender extends GenericSender implements IReportSend
   }
 
   @Override
-  public void send(List<MeasureReport> masterMeasureReports, DocumentReference documentReference, HttpServletRequest request, Authentication auth, FhirDataProvider fhirDataProvider, BundlerConfig bundlerConfig) throws Exception {
+  public String send(List<MeasureReport> masterMeasureReports, DocumentReference documentReference, HttpServletRequest request, FhirDataProvider fhirDataProvider, BundlerConfig bundlerConfig) throws Exception {
     Bundle bundle = this.generateBundle(documentReference, masterMeasureReports, fhirDataProvider, bundlerConfig);
 
     this.sendContent(bundle, documentReference, fhirDataProvider);
+
+    // TODO - return a location where document was sent.
+    return "";
   }
 
   /**

--- a/nhsn/src/main/java/com/lantanagroup/link/nhsn/FHIRSender.java
+++ b/nhsn/src/main/java/com/lantanagroup/link/nhsn/FHIRSender.java
@@ -4,7 +4,6 @@ import com.lantanagroup.link.FhirDataProvider;
 import com.lantanagroup.link.FhirHelper;
 import com.lantanagroup.link.GenericSender;
 import com.lantanagroup.link.IReportSender;
-import com.lantanagroup.link.auth.LinkCredentials;
 import com.lantanagroup.link.config.bundler.BundlerConfig;
 import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.r4.model.Bundle;
@@ -13,7 +12,6 @@ import org.hl7.fhir.r4.model.MeasureReport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -26,13 +24,15 @@ public class FHIRSender extends GenericSender implements IReportSender {
   protected static final Logger logger = LoggerFactory.getLogger(FHIRSender.class);
 
   @Override
-  public void send(List<MeasureReport> masterMeasureReports, DocumentReference documentReference, HttpServletRequest request, Authentication auth, FhirDataProvider fhirDataProvider, BundlerConfig bundlerConfig) throws Exception {
+  public String send(List<MeasureReport> masterMeasureReports, DocumentReference documentReference, HttpServletRequest request, FhirDataProvider fhirDataProvider, BundlerConfig bundlerConfig) throws Exception {
     Bundle bundle = this.generateBundle(documentReference, masterMeasureReports, fhirDataProvider, bundlerConfig);
     String location = this.sendContent(bundle, documentReference, fhirDataProvider);
 
     if (StringUtils.isNotEmpty(location)) {
       FhirHelper.setSubmissionLocation(documentReference, location);
     }
+
+    return location;
   }
 
   public String bundle(Bundle bundle, FhirDataProvider fhirDataProvider, String type) {

--- a/nhsn/src/main/java/com/lantanagroup/link/nhsn/FileSystemSender.java
+++ b/nhsn/src/main/java/com/lantanagroup/link/nhsn/FileSystemSender.java
@@ -14,7 +14,6 @@ import org.hl7.fhir.r4.model.MeasureReport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
 import javax.servlet.http.HttpServletRequest;
@@ -75,7 +74,7 @@ public class FileSystemSender extends GenericSender implements IReportSender {
     }
 
     @Override
-    public void send(List<MeasureReport> masterMeasureReports, DocumentReference documentReference, HttpServletRequest request, Authentication auth, FhirDataProvider fhirDataProvider, BundlerConfig bundlerConfig) throws Exception {
+    public String send(List<MeasureReport> masterMeasureReports, DocumentReference documentReference, HttpServletRequest request, FhirDataProvider fhirDataProvider, BundlerConfig bundlerConfig) throws Exception {
         Bundle bundle = this.generateBundle(documentReference, masterMeasureReports, fhirDataProvider, bundlerConfig);
 
         FileSystemSenderConfig.Formats format = this.getFormat();
@@ -105,6 +104,8 @@ public class FileSystemSender extends GenericSender implements IReportSender {
         Files.write(filePath, content.getBytes(StandardCharsets.UTF_8));
 
         logger.info(String.format("Done saving submission bundle/report to %s", filePath.toString()));
+
+        return filePath.toString();
     }
 
     @Override

--- a/tasks/src/main/java/com/lantanagroup/link/tasks/SendReportsTask.java
+++ b/tasks/src/main/java/com/lantanagroup/link/tasks/SendReportsTask.java
@@ -1,0 +1,104 @@
+package com.lantanagroup.link.tasks;
+
+import ca.uhn.fhir.context.FhirContext;
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.lantanagroup.link.auth.OAuth2Helper;
+import com.lantanagroup.link.helpers.HttpExecutor;
+import com.lantanagroup.link.helpers.HttpExecutorResponse;
+import com.lantanagroup.link.model.Report;
+import com.lantanagroup.link.model.ReportBundle;
+import com.lantanagroup.link.tasks.config.SendReportsConfig;
+import org.apache.commons.text.StringSubstitutor;
+import org.apache.http.HttpHeaders;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.entity.ContentType;
+import org.hl7.fhir.r4.model.Task;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class SendReportsTask {
+    private static final Logger logger = LoggerFactory.getLogger(SendReportsTask.class);
+
+    public static void executeTask(SendReportsConfig config) throws Exception {
+        logger.info("SendReports - executeTask - Started");
+
+        try {
+
+            logger.info("Searching for un-sent reports at {}", config.getSearchReportsUrl());
+
+            URIBuilder searchReportUrlBuilder = new URIBuilder(config.getSearchReportsUrl());
+            searchReportUrlBuilder.addParameter("submitted", "false");
+
+            HttpGet searchRequest = new HttpGet(searchReportUrlBuilder.build());
+
+            String token = OAuth2Helper.getToken(config.getAuth());
+            if (token == null) {
+                String errorMessage = "Authentication failed. Please contact the system administrator.";
+                logger.error(errorMessage);
+                throw new Exception(errorMessage);
+            }
+            if (OAuth2Helper.validateHeaderJwtToken(token)) {
+                searchRequest.addHeader(HttpHeaders.AUTHORIZATION, String.format("Bearer %s", token));
+            } else {
+                throw new JWTVerificationException("Invalid token format");
+            }
+
+            searchRequest.addHeader(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.toString());
+
+            HttpExecutorResponse searchResponse = HttpExecutor.HttpExecutor(searchRequest);
+            logger.info("HTTP Response Code {}", searchResponse.getResponseCode());
+
+            if (searchResponse.getResponseCode() != 200) {
+                // Didn't get success status from API
+                throw new Exception(String.format("Expecting HTTP Status Code 200 from API, received %s", searchResponse.getResponseCode()));
+            }
+
+            ObjectMapper mapper = new ObjectMapper();
+            ReportBundle reports = mapper.readValue(searchResponse.getResponseBody(), ReportBundle.class);
+
+            logger.info("There are {} reports to send", reports.getTotalSize());
+
+            for (Report report : reports.getList()) {
+                logger.info("Preparing to send report '{}'", report.getId());
+
+                String sendUrl = getSendUrl(config.getSendReportUrl(), report.getId());
+                logger.info("Sending report to API via {}", sendUrl);
+
+                HttpPost sendRequest = new HttpPost(sendUrl);
+                sendRequest.addHeader(HttpHeaders.AUTHORIZATION, String.format("Bearer %s", token));
+
+                HttpExecutorResponse sendResponse = HttpExecutor.HttpExecutor(sendRequest);
+                logger.info("HTTP Response Code {}", sendResponse.getResponseCode());
+
+                if (sendResponse.getResponseCode() != 200) {
+                    // Didn't get success status from API
+                    throw new Exception(String.format("Expecting HTTP Status Code 200 from API, received %s", sendResponse.getResponseCode()));
+                }
+                FhirContext ctx = FhirContext.forR4();
+                Task task = ctx.newJsonParser().parseResource(Task.class, sendResponse.getResponseBody());
+
+                logger.info("Report '{}' has been sent.  Send Report Task started with id '{}'", report.getId(), task.getId());
+            }
+
+
+        } catch (Exception ex) {
+            logger.error("Issue with SendReport task - {}", ex.getMessage());
+            throw ex;
+        }
+
+        logger.info("SendReports - executeTask - Completed");
+    }
+
+    private static String getSendUrl(String templateUrl, String reportId) {
+        // Build URL using sendReportUrl and id from report
+        Map<String, Object> urlReplaceParams = new HashMap<>();
+        urlReplaceParams.put("reportid", reportId);
+        return StringSubstitutor.replace(templateUrl, urlReplaceParams, "${", "}");
+    }
+}

--- a/tasks/src/main/java/com/lantanagroup/link/tasks/config/SendReportsConfig.java
+++ b/tasks/src/main/java/com/lantanagroup/link/tasks/config/SendReportsConfig.java
@@ -1,0 +1,23 @@
+package com.lantanagroup.link.tasks.config;
+
+import com.lantanagroup.link.config.YamlPropertySourceFactory;
+import com.lantanagroup.link.config.auth.LinkOAuthConfig;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.validation.annotation.Validated;
+
+@Getter
+@Setter
+
+@Configuration
+@ConfigurationProperties(prefix = "cli.send-reports")
+@Validated
+@PropertySource(value = "classpath:application.yml", factory = YamlPropertySourceFactory.class)
+public class SendReportsConfig {
+    private String searchReportsUrl;
+    private String sendReportUrl;
+    private LinkOAuthConfig auth;
+}

--- a/terraform/components/lambda-send-reports.tf
+++ b/terraform/components/lambda-send-reports.tf
@@ -1,0 +1,162 @@
+resource "aws_iam_role" "send-reports" {
+  max_session_duration = "3600"
+  name = "${var.environment}-${var.customer}-${var.project_code}-send-reports-lambda"
+  path = "/service-role/"
+
+  assume_role_policy = jsonencode({
+    "Statement": [
+      {
+        "Action": "sts:AssumeRole",
+        "Effect": "Allow",
+        "Principal": {
+          "Service": "lambda.amazonaws.com"
+        }
+      }
+    ],
+    "Version": "2012-10-17"
+  })
+
+  inline_policy {
+    name = "ReadExpungeSecret"
+    policy = jsonencode({
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": [
+            "secretsmanager:GetSecretValue",
+            "secretsmanager:DescribeSecret"
+          ],
+          "Effect": "Allow",
+          "Resource": [
+            aws_secretsmanager_secret.api-authentication.arn
+          ]
+          "Sid": "VisualEditor0"
+        }
+      ]
+    })
+  }
+
+  // TODO - name the actual lambda in resource - getting cyclical error currently.
+  inline_policy {
+    name = "CreateLogGroup"
+    policy = jsonencode({
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Action": "logs:CreateLogGroup",
+          "Resource": "arn:aws:logs:us-east-1:${var.aws_account}:*"
+        },
+        {
+          "Effect": "Allow",
+          "Action": [
+            "logs:CreateLogStream",
+            "logs:PutLogEvents"
+          ],
+          "Resource": [
+            "arn:aws:logs:us-east-1:${var.aws_account}:log-group:/aws/lambda/*"
+          ]
+        }
+      ]
+    })
+  }
+}
+
+resource "aws_iam_role" "send-reports-lambda-scheduler-role" {
+  name = "${var.environment}-${var.customer}-${var.project_code}-send-reports-scheduler-role"
+  assume_role_policy = jsonencode({
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Principal": {
+          "Service": "scheduler.amazonaws.com"
+        },
+        "Action": "sts:AssumeRole",
+        "Condition": {
+          "StringEquals": {
+            "aws:SourceAccount": var.aws_account
+          }
+        }
+      }
+    ]
+  })
+
+  max_session_duration = "3600"
+
+  inline_policy {
+    name = "${var.environment}-${var.customer}-${var.project_code}-RunLambda"
+    policy = jsonencode({
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Action": [
+            "lambda:InvokeFunction"
+          ],
+          "Resource": [
+            "arn:aws:lambda:us-east-1:${var.aws_account}:function:${aws_lambda_function.send-reports.function_name}:*",
+            "arn:aws:lambda:us-east-1:${var.aws_account}:function:${aws_lambda_function.send-reports.function_name}"
+          ]
+        }
+      ]
+    })
+  }
+  tags = {
+    Environment = var.environment,
+    CreatedBy = "terraform"
+  }
+}
+
+resource "aws_lambda_function" "send-reports" {
+
+  function_name = "${var.environment}-${var.customer}-${var.project_code}-send-reports"
+  role = aws_iam_role.send-reports.arn
+  handler = "SendReports"
+  runtime = "java17"
+  timeout = 900
+  s3_bucket = data.terraform_remote_state.infra.outputs.lambda_deploy_bucket.bucket
+  s3_key = module.lambda-jar.s3-file.key
+  s3_object_version = module.lambda-jar.s3-file.version_id
+
+  tags = {
+    Environment = var.environment,
+    CreatedBy = "terraform"
+  }
+
+  # PLEASE NOTE - the double $$ below in the send report url.  We are using ${} as a
+  # template placeholder but that blows up terraform.  Adding the extra $ escapes that.
+
+  environment {
+    variables = {
+      API_AUTH_SECRET = aws_secretsmanager_secret.api-authentication.name
+      SEND_REPORT_URL = "https://thsa1.sanerproject.org:10440/api/report/$${reportid}/$send"
+      SEARCH_REPORTS_URL = "https://thsa1.sanerproject.org:10440/api/report"
+    }
+  }
+}
+
+resource "aws_scheduler_schedule" "send-reports" {
+  name = "${var.environment}-${var.customer}-${var.project_code}-send-reports-lambda"
+  group_name = "default"
+
+  flexible_time_window {
+    mode = "OFF"
+  }
+
+  schedule_expression = "rate(1 days)"
+
+  target {
+    arn      = aws_lambda_function.send-reports.arn
+    role_arn = aws_iam_role.send-reports-lambda-scheduler-role.arn
+    input = jsonencode({})
+  }
+}
+
+
+resource "aws_lambda_permission" "send-reports" {
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.send-reports.function_name
+  principal     = "events.amazonaws.com"
+  source_arn = aws_scheduler_schedule.send-reports.arn
+}

--- a/thsa/src/main/java/com/lantanagroup/link/thsa/MeasureReportSender.java
+++ b/thsa/src/main/java/com/lantanagroup/link/thsa/MeasureReportSender.java
@@ -7,7 +7,6 @@ import com.lantanagroup.link.config.bundler.BundlerConfig;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.DocumentReference;
 import org.hl7.fhir.r4.model.MeasureReport;
-import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
 import javax.servlet.http.HttpServletRequest;
@@ -16,17 +15,20 @@ import java.util.List;
 @Component
 public class MeasureReportSender extends GenericSender implements IReportSender {
   @Override
-  public void send(List<MeasureReport> masterMeasureReports, DocumentReference documentReference, HttpServletRequest request, Authentication auth, FhirDataProvider fhirDataProvider, BundlerConfig bundlerConfig) throws Exception {
+  public String send(List<MeasureReport> masterMeasureReports, DocumentReference documentReference, HttpServletRequest request, FhirDataProvider fhirDataProvider, BundlerConfig bundlerConfig) throws Exception {
+    String returnLocation;
     if (masterMeasureReports.size() == 1) {
-      this.sendContent(masterMeasureReports.get(0), documentReference, fhirDataProvider);
+      returnLocation = this.sendContent(masterMeasureReports.get(0), documentReference, fhirDataProvider);
     } else {
       Bundle bundle = new Bundle();
       bundle.setType(Bundle.BundleType.COLLECTION);
       for (MeasureReport masterMeasureReport : masterMeasureReports) {
         bundle.addEntry().setResource(masterMeasureReport);
       }
-      this.sendContent(bundle, documentReference, fhirDataProvider);
+      returnLocation = this.sendContent(bundle, documentReference, fhirDataProvider);
     }
+
+    return returnLocation;
   }
 
   @Override


### PR DESCRIPTION
- API report search (/api/report) now allows you to specify a true/false for "submitted" to attempt to find reports that have or have not been submitted.  Current setup is that a DocumentReference that has been submitted with have docStatus = final and the *date* field set.  Non-submitted will likely be preliminary (but not final) and the *date* field shouldn't have a value.  
	- So if submitted=true when called then we do a ?docStatus=final call to the Data Store for DocumentReference.  Then there is a 2nd check that will remove any that are returned where the date has not been set.
	- If submitted=false when called then we do a ?\_filter=docStatus ne final call to the Data Store for DocumentReference.  Then there is a 2nd check that will remove any that are returned where the date has been set.
- To help with the above we have had to add a new parameter to the Data Store code when it starts up for filter-parameter-enabled as this was not enabled by default.
	- A new parameter, filterParameterEnabled, has been added to com.lantanagroup.link.config.datastore.DataStoreDaoConfig.
	- This leads us to need a filter-parameter-enabled added to the configuration file read in by the DataStore.
	- Update to daoConfig() function in com.lantanagroup.link.datastore.DataStoreApplication to read in the new parameter and apply as the Data Store starts up.
- Added documentReferenceId as a piece of data returned in the Report model (com.lantanagroup.link.model.Report).  Serves no purpose other than to give you the actual id the DocumentReference on the Data Store for that Report item.
- IReportSender no longer requires auth, wasn't being used and causing me an issue :)
- API send report (/api/report/<reportId>/$send) now returns a Task and kicks off background process.
	- Small tweak to IReportSender and implementations so that send() returns a string which is the location where the report was sent.
- Created SendReportsTask to contain code for searching the API for un-sent reports and send them.
- Created SendReports cli to call SendReportsTask via the Spring Boot command framework.
- Needed to add a default constructor to com.lantanagroup.link.model.Report so that Jackson read to object would work on return from API when searching for reports to send.
- Created SendReports lambda function to work in AWS.
- SendReports lambda setup and deployed via terraform.