### PR TITLE
THSALINK-028

### DIFF
--- a/terraform/components/ecs-task-keycloak.tf
+++ b/terraform/components/ecs-task-keycloak.tf
@@ -10,7 +10,8 @@ module "ecs-task-keycloak" {
   project_code = var.project_code
 
   # TFVARS
-  image_repository = "quay.io/keycloak"
+  //image_repository = "quay.io/keycloak"
+  image_repository = var.docker_image_repository
   image_name = var.keycloak_docker_image_name
   image_tag = var.keycloak_docker_tag
   ecs_task_role = data.terraform_remote_state.infra.outputs.iam-role-arn

--- a/terraform/infrastructure/ecr.tf
+++ b/terraform/infrastructure/ecr.tf
@@ -73,3 +73,10 @@ resource "aws_ecrpublic_repository" "thsa-link-cli-parkland-csv" {
     CreatedBy = "terraform"
   }
 }
+
+resource "aws_ecrpublic_repository" "thsa-link-keycloak" {
+  repository_name = "thsa-link-keycloak"
+  tags = {
+    CreatedBy = "terraform"
+  }
+}

--- a/terraform/modules/ecs-task/ecs-task.tf
+++ b/terraform/modules/ecs-task/ecs-task.tf
@@ -24,7 +24,7 @@ resource "aws_ecs_task_definition" "ecs_task" {
     "logDriver": "awslogs",
     "options": {
       "awslogs-create-group": "true",
-      "awslogs-group": "/ecs/",
+      "awslogs-group": "/${var.environment}-${var.customer}-${var.project_code}-${var.application_code}/",
       "awslogs-region": "us-east-1",
       "awslogs-stream-prefix": "ecs"
     },

--- a/terraform/modules/keycloak-ecs-task/keycloak-ecs-task.tf
+++ b/terraform/modules/keycloak-ecs-task/keycloak-ecs-task.tf
@@ -27,7 +27,7 @@ resource "aws_ecs_task_definition" "ecs_task" {
         "logDriver": "awslogs",
         "options": {
           "awslogs-create-group": "true",
-          "awslogs-group": "/ecs/",
+          "awslogs-group": "/${var.environment}-${var.customer}-${var.project_code}-${var.application_code}/",
           "awslogs-region": "us-east-1",
           "awslogs-stream-prefix": "ecs"
         },

--- a/web/src/main/angular/app/model/job-note.ts
+++ b/web/src/main/angular/app/model/job-note.ts
@@ -1,0 +1,4 @@
+export interface JobNote {
+    date: Date;
+    note: string;
+}

--- a/web/src/main/angular/app/model/job.ts
+++ b/web/src/main/angular/app/model/job.ts
@@ -1,0 +1,10 @@
+import {JobNote} from "./job-note";
+
+export interface Job {
+    id: string;
+    status: string;
+    type: string;
+    created: Date;
+    lastUpdated: Date;
+    notes: JobNote[];
+}

--- a/web/src/main/angular/app/report/report.component.ts
+++ b/web/src/main/angular/app/report/report.component.ts
@@ -209,24 +209,12 @@ export class ReportComponent implements OnInit, OnDestroy {
           'Once re-evaluated, the newest calculated aggregate totals will be updated in this report. ' +
           'Fields not calculated as part of the measure will not be affected. Are you sure you want to continue?')) {
         try {
-          const generateResponse = await this.reportService.generate(bundleIds, formatDateToISO(this.reportModel.reportPeriodStart), formatDateToISO(this.reportModel.reportPeriodEnd), true);
-          await this.router.navigate(['review', generateResponse.masterId]);
-          this.toastService.showInfo('Report re-generated!');
+          const generateResponse: Job = await this.reportService.generateNew(bundleIds, formatDateToISO(this.reportModel.reportPeriodStart), formatDateToISO(this.reportModel.reportPeriodEnd), true);
+          await this.router.navigate(['review']);
+          this.toastService.showInfo('Report re-generation started - Job id: ' + generateResponse.id);
           await this.initReport();
         } catch (ex) {
-          if (ex.status === 409) {
-            if (confirm(ex.error.message)) {
-              try {
-                const generateResponse = await this.reportService.generate(bundleIds, formatDateToISO(this.reportModel.reportPeriodStart), formatDateToISO(this.reportModel.reportPeriodEnd), true);
-                await this.router.navigate(['review', generateResponse.masterId]);
-              } catch (ex) {
-                this.toastService.showException('Error re-generating report', ex);
-              }
-            }
-          } else {
-            this.toastService.showException('Error re-generating report', ex);
-          }
-          return;
+          this.toastService.showException('Error re-generating report: ' + this.masterId, ex);
         }
       }
     } catch (ex) {

--- a/web/src/main/angular/app/report/report.component.ts
+++ b/web/src/main/angular/app/report/report.component.ts
@@ -9,6 +9,7 @@ import {ReportModel} from "../model/ReportModel";
 import {ReportSaveModel} from "../model/ReportSaveModel"
 import {CodeableConcept} from "../model/fhir";
 import {formatDateToISO} from "../helper";
+import {Job} from '../model/job';
 
 @Component({
   selector: 'report',
@@ -117,8 +118,8 @@ export class ReportComponent implements OnInit, OnDestroy {
       }
       if (confirm('Are you sure you want to submit this report?')) {
         this.submitInProgress = true;
-        await this.reportService.send(this.masterId.split('-')[0]);
-        this.toastService.showInfo('Report sent!');
+        const sendJob: Job = await this.reportService.send(this.masterId.split('-')[0]);
+        this.toastService.showInfo('Report send started - Job id ' + sendJob.id);
         await this.router.navigate(['/review']);
       }
     } catch (ex) {

--- a/web/src/main/angular/app/review/review.component.html
+++ b/web/src/main/angular/app/review/review.component.html
@@ -80,7 +80,7 @@
     </tr>
     </thead>
     <tbody>
-    <tr *ngFor="let report of reports">
+    <tr *ngFor="let report of reports | slice: (page-1) * pageSize : page * pageSize">
         <td>
             {{getMeasureName(report.reportMeasure)}}
         </td>

--- a/web/src/main/angular/app/review/review.component.ts
+++ b/web/src/main/angular/app/review/review.component.ts
@@ -99,37 +99,44 @@ export class ReviewComponent implements OnInit {
 
   getFilterCriteria() {
     let filterCriteria = '';
-    if (this.filter.reportTypeId == "") {
-      if (this.filter.measure !== "Select measure") {
-        // find the measure
-        const measure = this.measures.find(p => p.name === this.filter.measure);
-        filterCriteria += `identifier=${encodeURIComponent(measure.system + "|" + measure.id)}&`
-      }
-      if (this.filter.status !== 'Select status') {
-        const status = this.statuses.find(p => p.name === this.filter.status);
-        filterCriteria += `docStatus=${encodeURIComponent(status.value)}&`
-      }
-      if (this.filter.period.startDate !== null) {
-        let startDate = formatDateToISO(getFhirDate(this.filter.period.startDate));
-        filterCriteria += `periodStartDate=${startDate}&`
-      }
-      if (this.filter.period.endDate !== null) {
-        let endDate = formatDateToISO(getFhirDate(this.filter.period.endDate));
-        filterCriteria += `periodEndDate=${getEndOfDayDate(endDate)}&`
-      }
-      if (this.filter.submittedDate !== null) {
-        let submittedDate = formatDateToISO(getFhirDate(this.filter.submittedDate));
-        filterCriteria += `submittedDate=${submittedDate}&`
-      }
-      if (this.filter.submitter !== "Select submitter") {
-        // find the submitter
-        const submitter = this.submitters.find(p => p.name === this.filter.submitter);
-        filterCriteria += `author=${submitter.id}`
-      }
-    } else {
-      filterCriteria += `bundleId=${this.filter.reportTypeId}&`
-      filterCriteria += `page=${this.page}`
+
+    if (this.filter.measure !== 'Select measure') {
+      // find the measure
+      const measure = this.measures.find(p => p.name === this.filter.measure);
+      filterCriteria += `identifier=${encodeURIComponent(measure.system + '|' + measure.id)}&`;
     }
+
+    if (this.filter.status !== 'Select status') {
+      const status = this.statuses.find(p => p.name === this.filter.status);
+      filterCriteria += `docStatus=${encodeURIComponent(status.value)}&`;
+    }
+
+    if (this.filter.period.startDate !== null) {
+      const startDate = formatDateToISO(getFhirDate(this.filter.period.startDate));
+      filterCriteria += `periodStartDate=${startDate}&`;
+    }
+
+    if (this.filter.period.endDate !== null) {
+      const endDate = formatDateToISO(getFhirDate(this.filter.period.endDate));
+      filterCriteria += `periodEndDate=${getEndOfDayDate(endDate)}&`;
+    }
+
+    if (this.filter.submittedDate !== null) {
+      const submittedDate = formatDateToISO(getFhirDate(this.filter.submittedDate));
+      filterCriteria += `submittedDate=${submittedDate}&`;
+    }
+
+    if (this.filter.submitter !== 'Select submitter') {
+      // find the submitter
+      const submitter = this.submitters.find(p => p.name === this.filter.submitter);
+      filterCriteria += `author=${submitter.id}`;
+    }
+
+    if (this.filter.reportTypeId !== '') {
+      filterCriteria += `bundleId=${this.filter.reportTypeId}&`;
+      filterCriteria += `page=${this.page}`;
+    }
+
     return filterCriteria;
   }
 

--- a/web/src/main/angular/app/services/report.service.ts
+++ b/web/src/main/angular/app/services/report.service.ts
@@ -10,6 +10,7 @@ import {map} from 'rxjs/operators';
 import {ReportModel} from "../model/ReportModel";
 import {ReportSaveModel} from "../model/ReportSaveModel";
 import {PatientDataModel} from "../model/PatientDataModel";
+import {Job} from "../model/job";
 
 @Injectable()
 export class ReportService {
@@ -29,6 +30,18 @@ export class ReportService {
     return await this.http.post<GenerateResponse>(url, generateRequest).toPromise();
   }
 
+  async generateNew(bundleIds: string[], periodStart: string, periodEnd: string, regenerate = false) {
+    let url = 'report/$generate?';
+    url = this.configService.getApiUrl(url);
+    const generateRequest = {
+      bundleIds,
+      periodStart,
+      periodEnd,
+      regenerate: (regenerate ? 'true' : 'false')
+    };
+    return await this.http.post<Job>(url, generateRequest).toPromise();
+  }
+
   getReports(queryParams) {
     let url = this.configService.getApiUrl('report?');
     if (queryParams !== undefined && queryParams !== '') {
@@ -44,7 +57,7 @@ export class ReportService {
 
   async send(reportId: string) {
     const url = this.configService.getApiUrl(`report/${encodeURIComponent(reportId)}/$send`);
-    return this.http.post(url, null).toPromise();
+    return this.http.post<Job>(url, null).toPromise();
   }
 
   async download(reportId: string, type: string) {


### PR DESCRIPTION
- Web Component now understands the Jobs object.  Generate and Send now receive the Job object from the API and display the ID in an information pop-up.  Eventually may need to update the Web component to have a Job tab.
- Terraform - ECS tasks now log to their own group labeled with the environment-customer-project_code.  Previously everything was in a /ecs/ group.  This will help segregate things as new PoC's come online.
- Terraform - increase uscore.parallel-patients to 20 (from 10) to try and speed up report generation.
- Web Component - Got pagination working on review.  This did break filtering because, for example, if you choose Status = Submitted once you start going through pages the status filter gets blanked out.
- Web Component - Fixed the status blank-out issue mentioned above.
- Terraform - Keycloak image pulled from quay.io and added to a public ECR.  Updates so that keycloak ECS deployment pulls from the public ECR.